### PR TITLE
Restored transparency of saved and loaded image files and other fixes

### DIFF
--- a/artpaint/layers/Layer.cpp
+++ b/artpaint/layers/Layer.cpp
@@ -50,7 +50,7 @@ Layer::Layer(BRect frame, int32 id, ImageView* imageView, layer_type type,
 
 		fLayerData = new BBitmap(BRect(frame.LeftTop(),
 			BPoint(max_c(frame.right, sourceRect.right),
-				max_c(frame.bottom, sourceRect.bottom))), B_RGB_32_BIT);
+				max_c(frame.bottom, sourceRect.bottom))), B_RGBA32);
 
 		if (!fLayerData->IsValid())
 			throw std::bad_alloc();

--- a/artpaint/layers/LayerWindow.cpp
+++ b/artpaint/layers/LayerWindow.cpp
@@ -94,6 +94,7 @@ LayerWindow::~LayerWindow()
 	acquire_sem(layer_window_semaphore);
 	while (layer_window->list_view->CountChildren() != 0)
 		layer_window->list_view->RemoveChild(layer_window->list_view->ChildAt(0));
+	layer_window = NULL;
 	release_sem(layer_window_semaphore);
 
 	if (SettingsServer* server = SettingsServer::Instance()) {
@@ -104,7 +105,6 @@ LayerWindow::~LayerWindow()
 	}
 
 	FloaterManager::RemoveFloater(this);
-	layer_window = NULL;
 }
 
 

--- a/artpaint/paintwindow/Image.cpp
+++ b/artpaint/paintwindow/Image.cpp
@@ -264,13 +264,13 @@ bool Image::SetImageSize()
 	if (layer_list->CountItems() >= 1) {
 		if (rendered_image == NULL) {
 			// Here we create new composite picture.
-			rendered_image = new BBitmap(BRect(0,0,image_width-1,image_height-1),B_RGB32);
+			rendered_image = new BBitmap(BRect(0,0,image_width-1,image_height-1),B_RGBA32);
 		}
 		else if ((rendered_image->Bounds().Width() != (image_width-1)) || (rendered_image->Bounds().Height() != (image_height-1))) {
 			// Here we change the bitmap for the composite picture. Also if the dithered picture
 			// is required we change that too.
 			delete rendered_image;
-			rendered_image = new BBitmap(BRect(0,0,image_width-1,image_height-1),B_RGB32);
+			rendered_image = new BBitmap(BRect(0,0,image_width-1,image_height-1),B_RGBA32);
 			if (dithered_image != NULL) {
 				delete dithered_image;
 				dithered_image = new BBitmap(BRect(0,0,image_width-1,image_height-1),B_CMAP8);
@@ -350,7 +350,7 @@ Layer* Image::AddLayer(BBitmap *bitmap,Layer *next_layer,bool add_to_front,float
 
 		// if this is the first layer we should create the composite picture
 		if ((layer_list->CountItems() == 1) && (rendered_image == NULL) ) {
-			rendered_image = new BBitmap(BRect(0,0,image_width-1,image_height-1),B_RGB32);
+			rendered_image = new BBitmap(BRect(0,0,image_width-1,image_height-1),B_RGBA32);
 			if (rendered_image->IsValid() == FALSE) {
 				// If the creation of composite picture fails we should remove the newly added
 				// layer and inform the user that we cannot add a layer. The method that called
@@ -853,7 +853,7 @@ status_t Image::ReadLayers(BFile &file)
 			layer->ActivateLayer(FALSE);	// We activate only the first read layer
 			// if this is the first layer we should create the composite picture
 			if ((layer_list->CountItems() == 1) && (rendered_image == NULL) ) {
-				rendered_image = new BBitmap(BRect(0,0,image_width-1,image_height-1),B_RGB32);
+				rendered_image = new BBitmap(BRect(0,0,image_width-1,image_height-1),B_RGBA32);
 				if (rendered_image->IsValid() == FALSE) {
 					// If the creatioin of composite picture fails we should remove the newly added
 					// layer and inform the user that we cannot add a layer. The method that called
@@ -931,7 +931,7 @@ status_t Image::ReadLayersOldStyle(BFile &file,int32 count)
 			layer->ActivateLayer(FALSE);	// We activate only the first read layer
 			// if this is the first layer we should create the composite picture
 			if ((layer_list->CountItems() == 1) && (rendered_image == NULL) ) {
-				rendered_image = new BBitmap(BRect(0,0,image_width-1,image_height-1),B_RGB32);
+				rendered_image = new BBitmap(BRect(0,0,image_width-1,image_height-1),B_RGBA32);
 				if (rendered_image->IsValid() == FALSE) {
 					// If the creatioin of composite picture fails we should remove the newly added
 					// layer and inform the user that we cannot add a layer. The method that called

--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -1800,7 +1800,7 @@ status_t ImageView::DoCopyOrCut(int32 layers,bool cut)
 			BRect bounds = selection_bounds;
 
 			bounds.OffsetTo(0,0);
-			BBitmap *to_be_archived = new BBitmap(bounds,B_RGB32,0); //staragter
+			BBitmap *to_be_archived = new BBitmap(bounds,B_RGBA32,0); //stargater, Pete
 			uint32 *target_bits = (uint32*)to_be_archived->Bits();
 			int32 bits_length = to_be_archived->BitsLength()/4;
 			union {

--- a/artpaint/viewmanipulators/RotationManipulator.cpp
+++ b/artpaint/viewmanipulators/RotationManipulator.cpp
@@ -24,6 +24,7 @@
 #include "Selection.h"
 #include "HSPolygon.h"
 #include "StringServer.h"
+#include "SysInfoBeOS.h"
 
 
 #define PI M_PI
@@ -105,9 +106,10 @@ void RotationManipulator::SetPreviewBitmap(BBitmap *bitmap)
 	}
 
 	if (preview_bitmap != NULL) {
-		system_info info;
-		get_system_info(&info);
-		double speed = info.cpu_count * 2000; // TODO: used to be info.cpu_clock_speed but was removed
+		// Use a custom header to get the legacy system_info with cpu speed
+		BeOS_system_info info;
+		get_BeOS_system_info(&info);
+		double speed = info.cpu_count * info.cpu_clock_speed;
 		speed = speed / 15000;
 
 		BRect bounds = preview_bitmap->Bounds();

--- a/artpaint/viewmanipulators/SysInfoBeOS.h
+++ b/artpaint/viewmanipulators/SysInfoBeOS.h
@@ -1,0 +1,63 @@
+/*
+* Recreation of the original BeOS system_info struct
+* to provide legacy apps with cpu_speed, etc.
+*
+* (The original enums for cpu_type and platform_type
+* are here just ints)
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#define		B_MAX_CPU_COUNT		8
+
+
+typedef struct {
+	bigtime_t		active_time;		/* # usec doing useful work since boot */
+} BeOS_cpu_info;
+
+
+typedef int32 machine_id[2];		/* unique machine ID */
+
+typedef struct {
+	machine_id	   id;							/* unique machine ID */
+	bigtime_t	   boot_time;					/* time of boot (# usec since 1/1/70) */
+
+	int32		   cpu_count;					/* # of cpus */
+	int32          cpu_type;					/* type of cpu */
+	int32		   cpu_revision;				/* revision # of cpu */
+	BeOS_cpu_info  cpu_infos[B_MAX_CPU_COUNT];	/* info about individual cpus */
+	int64          cpu_clock_speed;	 			/* processor clock speed (Hz) */
+	int64          bus_clock_speed;				/* bus clock speed (Hz) */
+	int32          platform_type;          /* type of machine we're on */
+
+	int32		  max_pages;					/* total # physical pages */
+	int32		  used_pages;					/* # physical pages in use */
+	int32		  page_faults;					/* # of page faults */
+	int32		  max_sems;						/* maximum # semaphores */
+	int32		  used_sems;					/* # semaphores in use */
+	int32		  max_ports;					/* maximum # ports */
+	int32		  used_ports;					/* # ports in use */
+	int32		  max_threads;					/* maximum # threads */
+	int32		  used_threads;					/* # threads in use */
+	int32		  max_teams;					/* maximum # teams */
+	int32		  used_teams;					/* # teams in use */
+
+	char		  kernel_name [B_FILE_NAME_LENGTH];		/* name of kernel */
+	char          kernel_build_date[B_OS_NAME_LENGTH];	/* date kernel built */
+	char          kernel_build_time[B_OS_NAME_LENGTH];	/* time kernel built */
+	int64         kernel_version;             	/* version of this kernel */
+
+	bigtime_t	  _busy_wait_time;				/* reserved for Be */
+	int32         pad[4];   	               	/* just in case... */
+} BeOS_system_info;
+
+
+extern  status_t _get_system_info (BeOS_system_info *returned_info, size_t size);
+#define get_BeOS_system_info(info)  _get_system_info((info), sizeof(*(info)))
+
+#ifdef __cplusplus
+}
+#endif

--- a/artpaint/viewmanipulators/TranslationManipulator.cpp
+++ b/artpaint/viewmanipulators/TranslationManipulator.cpp
@@ -21,6 +21,7 @@
 #include "TranslationManipulator.h"
 #include "StringServer.h"
 #include "NumberControl.h"
+#include "SysInfoBeOS.h"
 
 
 using ArtPaint::Interface::NumberControl;
@@ -406,9 +407,10 @@ void TranslationManipulator::SetPreviewBitmap(BBitmap *bm)
 	}
 
 	if (preview_bitmap != NULL) {
-		system_info info;
-		get_system_info(&info);
-		double speed = info.cpu_count * 2000; // TODO: used to be info.cpu_clock_speed but was removed
+		// Use a custom header to get the legacy system_info with cpu speed
+		BeOS_system_info info;
+		get_BeOS_system_info(&info);
+		double speed = info.cpu_count * info.cpu_clock_speed;
 		speed = speed / 1000;
 
 		BRect bounds = preview_bitmap->Bounds();


### PR DESCRIPTION
I merged my previous branch that fixed dynamic display to master, and corrected RGB32 bitmaps to RGBA32, so that transparency in an image is preserved (for PNG etc) when it is saved.  Also now preserves the transparency of a loaded image.  COrrected a badly-placed semaphore that allowed a race-condition crash when the Layer Window was closed.
