### PR TITLE
Some GUI work in the add-ons

### DIFF
--- a/Documentation/add_ons.html
+++ b/Documentation/add_ons.html
@@ -138,7 +138,7 @@ around.
 controls sliders for controlling the length and the strength of the 
 wave. The wave center can be adjusted by clicking on the image with 
 the mouse and dragging around.
-<DT><b>PerlinWood</b>
+<DT><b>Wood</b>
 <DD>Creates a wood-like texture over the image.
 </DL>
 </TR>

--- a/addons/AddOns/Working/AdaptiveHistogramEqualization/AHEManipulator.cpp
+++ b/addons/AddOns/Working/AdaptiveHistogramEqualization/AHEManipulator.cpp
@@ -17,8 +17,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-	char name[255] = "Adaptive Histogram Equalization";
-	char menu_help_string[255] = "Improves the contrast of the active layer by equalizing its histogram locally.";
+	char name[255] = "Adaptive histogram equalization";
+	char menu_help_string[255] = "Improves the contrast by equalizing its histogram locally.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = COLOR_ADD_ON;
 #ifdef __cplusplus

--- a/addons/AddOns/Working/AntiDitherer/AntiDitherer.cpp
+++ b/addons/AddOns/Working/AntiDitherer/AntiDitherer.cpp
@@ -9,6 +9,7 @@
 #include <Bitmap.h>
 #include <CheckBox.h>
 #include <ClassInfo.h>
+#include <LayoutBuilder.h>
 #include <StatusBar.h>
 #include <string.h>
 #include <Window.h>
@@ -25,8 +26,8 @@ using ArtPaint::Interface::NumberControl;
 #ifdef __cplusplus
 extern "C" {
 #endif
-	char name[255] = "AntiDitherer…";
-	char menu_help_string[255] = "Starts adjusting the image saturation.";
+	char name[255] = "Anti-Dither…";
+	char menu_help_string[255] = "Attempts to reverse the effects of dithering.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = COLOR_ADD_ON;
 #ifdef __cplusplus
@@ -256,12 +257,12 @@ void AntiDithererManipulator::ChangeSettings(ManipulatorSettings *s)
 
 char* AntiDithererManipulator::ReturnName()
 {
-	return "AntiDitherer";
+	return "Anti-Dither";
 }
 
 char* AntiDithererManipulator::ReturnHelpString()
 {
-	return "Use the slider to set the image saturation.";
+	return "Attempts to reverse the effects of dithering.";
 }
 
 
@@ -276,18 +277,18 @@ AntiDithererManipulatorView::AntiDithererManipulatorView(AntiDithererManipulator
 	manipulator = manip;
 	started_adjusting = FALSE;
 
-	block_size_control = new NumberControl("Block size", "0",
+	block_size_control = new NumberControl("Block size:", "0",
 		new BMessage(BLOCK_SIZE_ADJUSTED));
-	AddChild(block_size_control);
-	block_size_control->ResizeToPreferred();
-	block_size_control->MoveTo(BPoint(4,4));
-	BRect frame = block_size_control->Frame();
 
-	reduce_resolution_box = new BCheckBox(BRect(4, frame.Height()+4, StringWidth("Reduce resolution")+40, frame.Height()+24),
+	reduce_resolution_box = new BCheckBox(
 		"reduce_resolution","Reduce resolution",new BMessage(REDUCE_RESOLUTION_ADJUSTED));
-	AddChild(reduce_resolution_box);
+	reduce_resolution_box->SetExplicitMaxSize(BSize(B_SIZE_UNLIMITED, B_SIZE_UNSET));
 
-	ResizeTo(reduce_resolution_box->Bounds().Width()+8,reduce_resolution_box->Frame().bottom+4);
+	BLayoutBuilder::Group<>(this, B_VERTICAL, B_USE_ITEM_SPACING)
+		.Add(block_size_control)
+		.Add(reduce_resolution_box)
+		.SetInsets(B_USE_SMALL_INSETS)
+		.End();
 }
 
 AntiDithererManipulatorView::~AntiDithererManipulatorView()

--- a/addons/AddOns/Working/BlurAddOn/Blur.cpp
+++ b/addons/AddOns/Working/BlurAddOn/Blur.cpp
@@ -7,6 +7,7 @@
  *
  */
 #include <Bitmap.h>
+#include <LayoutBuilder.h>
 #include <Node.h>
 #include <StatusBar.h>
 #include <Slider.h>
@@ -24,7 +25,7 @@ extern "C" {
 #endif
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	char name[255] = "Blur…";
-	char menu_help_string[255] = "Starts blurring the active layer.";
+	char menu_help_string[255] = "Adds a blur.";
 	add_on_types add_on_type = BLUR_FILTER_ADD_ON;
 #ifdef __cplusplus
 }
@@ -591,22 +592,22 @@ BlurManipulatorView::BlurManipulatorView(BRect rect,BlurManipulator *manip,
 	manipulator = manip;
 	target = new BMessenger(t);
 
-	blur_amount_slider = new BSlider(BRect(0,0,150,0), "blur_amount_slider",
-		"Blur amount", new BMessage(BLUR_AMOUNT_CHANGED), 1, MAX_BLUR_AMOUNT,
+	blur_amount_slider = new BSlider("blur_amount_slider",
+		"Blur amount:", new BMessage(BLUR_AMOUNT_CHANGED), 1, MAX_BLUR_AMOUNT,
 		B_HORIZONTAL, B_TRIANGLE_THUMB);
-	blur_amount_slider->SetLimitLabels("Little","Much");
-	blur_amount_slider->ResizeToPreferred();
-	blur_amount_slider->MoveTo(4,4);
+	blur_amount_slider->SetLimitLabels("Low","High");
+	blur_amount_slider->SetHashMarks(B_HASH_MARKS_BOTTOM);
+	blur_amount_slider->SetHashMarkCount(11);
 //	blur_amount_slider->SetModificationMessage(new BMessage(BLUR_AMOUNT_CHANGE_STARTED));
 
 //	BRect frame_rect = blur_amount_slider->Frame();
 //	frame_rect.bottom = frame_rect.top;
 //	transparency_checkbox = new BCheckBox(frame_rect,"transparency_checkbox","Blur Transparency",new BMessage(BLUR_TRANSPARENCY_CHANGED));
 
-	ResizeTo(blur_amount_slider->Frame().Width()+8,blur_amount_slider->Frame().Height()+8);
-
-	AddChild(blur_amount_slider);
-
+	BLayoutBuilder::Group<>(this, B_VERTICAL)
+		.Add(blur_amount_slider)
+		.SetInsets(B_USE_SMALL_INSETS)
+		.End();
 
 	preview_started = FALSE;
 }

--- a/addons/AddOns/Working/Brightness/Brightness.cpp
+++ b/addons/AddOns/Working/Brightness/Brightness.cpp
@@ -7,6 +7,7 @@
  *
  */
 #include <Bitmap.h>
+#include <LayoutBuilder.h>
 #include <Node.h>
 #include <StatusBar.h>
 #include <Slider.h>
@@ -23,7 +24,7 @@
 extern "C" {
 #endif
 	char name[255] = "Brightness…";
-	char menu_help_string[255] = "Starts adjusting the image brightness.";
+	char menu_help_string[255] = "Adjusts the brightness.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = COLOR_ADD_ON;
 #ifdef __cplusplus
@@ -385,16 +386,18 @@ BrightnessManipulatorView::BrightnessManipulatorView(BrightnessManipulator *mani
 	manipulator = manip;
 	started_adjusting = FALSE;
 
-	brightness_slider = new BSlider(BRect(0,0,200,0), "brightness_slider",
-		"Brightness", new BMessage(BRIGHTNESS_ADJUSTING_FINISHED), 0, 255,
+	brightness_slider = new BSlider("brightness_slider",
+		"Brightness:", new BMessage(BRIGHTNESS_ADJUSTING_FINISHED), 0, 255,
 		B_HORIZONTAL, B_TRIANGLE_THUMB);
 	brightness_slider->SetModificationMessage(new BMessage(BRIGHTNESS_ADJUSTED));
-	brightness_slider->SetLimitLabels("Dim","Bright");
-	brightness_slider->ResizeToPreferred();
-	brightness_slider->MoveTo(4,4);
-	AddChild(brightness_slider);
+	brightness_slider->SetLimitLabels("Low","High");
+	brightness_slider->SetHashMarks(B_HASH_MARKS_BOTTOM);
+	brightness_slider->SetHashMarkCount(11);
 
-	ResizeTo(brightness_slider->Bounds().Width()+8,brightness_slider->Bounds().Height()+8);
+	BLayoutBuilder::Group<>(this, B_VERTICAL)
+		.Add(brightness_slider)
+		.SetInsets(B_USE_SMALL_INSETS)
+		.End();
 }
 
 

--- a/addons/AddOns/Working/ColorBalanceAddOn/ColorBalance.cpp
+++ b/addons/AddOns/Working/ColorBalanceAddOn/ColorBalance.cpp
@@ -12,14 +12,15 @@
 #include "Selection.h"
 
 #include <Bitmap.h>
+#include <LayoutBuilder.h>
 #include <Slider.h>
 
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-	char name[255] = "Color Balance…";
-	char menu_help_string[255] = "Starts adjusting the color balance of the active layer.";
+	char name[255] = "Color balance…";
+	char menu_help_string[255] = "Adjusts the color balance.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = COLOR_ADD_ON;
 #ifdef __cplusplus
@@ -275,51 +276,54 @@ ColorBalanceManipulatorView::ColorBalanceManipulatorView(BRect rect,
 	preview_started = FALSE;
 	rgb_color color;
 
-	red_slider = new BSlider(BRect(0,0,150,0), "red_slider", NULL,
+	red_slider = new BSlider("red_slider", NULL,
 		new BMessage(HS_MANIPULATOR_ADJUSTING_FINISHED), -255, 255,
 		B_HORIZONTAL, B_TRIANGLE_THUMB);
-	red_slider->SetLimitLabels("Less red","More red");
-	red_slider->ResizeToPreferred();
+	red_slider->SetLimitLabels("Less","More");
+	red_slider->SetHashMarks(B_HASH_MARKS_BOTTOM);
+	red_slider->SetHashMarkCount(11);
 	red_slider->SetModificationMessage(new BMessage(HS_MANIPULATOR_ADJUSTING_STARTED));
 	color.red = 255;
 	color.blue = 0;
 	color.green = 0;
 	color.alpha = 255;
 	red_slider->SetBarColor(color);
-	AddChild(red_slider);
-	red_slider->MoveTo(4,4);
-	BRect frame = red_slider->Frame();
-	frame.OffsetBy(0,frame.Height()+4);
+	red_slider->SetBarThickness(8);
 
-	green_slider = new BSlider(frame, "green_slider", NULL,
+	green_slider = new BSlider("green_slider", NULL,
 		new BMessage(HS_MANIPULATOR_ADJUSTING_FINISHED), -255, 255,
 		B_HORIZONTAL, B_TRIANGLE_THUMB);
-	green_slider->SetLimitLabels("Less green","More green");
-	green_slider->ResizeToPreferred();
+	green_slider->SetLimitLabels("Less","More");
+	green_slider->SetHashMarks(B_HASH_MARKS_BOTTOM);
+	green_slider->SetHashMarkCount(11);
 	green_slider->SetModificationMessage(new BMessage(HS_MANIPULATOR_ADJUSTING_STARTED));
 	color.red = 0;
 	color.blue = 0;
 	color.green = 255;
 	color.alpha = 255;
 	green_slider->SetBarColor(color);
-	AddChild(green_slider);
-	frame = green_slider->Frame();
-	frame.OffsetBy(0,frame.Height()+4);
+	green_slider->SetBarThickness(8);
 
-	blue_slider = new BSlider(frame, "blue_slider", NULL,
+	blue_slider = new BSlider("blue_slider", NULL,
 		new BMessage(HS_MANIPULATOR_ADJUSTING_FINISHED), -255, 255,
 		B_HORIZONTAL, B_TRIANGLE_THUMB);
-	blue_slider->SetLimitLabels("Less blue","More blue");
-	blue_slider->ResizeToPreferred();
+	blue_slider->SetLimitLabels("Less","More");
+	blue_slider->SetHashMarks(B_HASH_MARKS_BOTTOM);
+	blue_slider->SetHashMarkCount(11);
 	blue_slider->SetModificationMessage(new BMessage(HS_MANIPULATOR_ADJUSTING_STARTED));
 	color.red = 0;
 	color.blue = 255;
 	color.green = 0;
 	color.alpha = 255;
 	blue_slider->SetBarColor(color);
-	AddChild(blue_slider);
+	blue_slider->SetBarThickness(8);
 
-	ResizeTo(blue_slider->Bounds().Width()+8,blue_slider->Frame().bottom + 4);
+	BLayoutBuilder::Group<>(this, B_VERTICAL, B_USE_ITEM_SPACING)
+		.Add(red_slider)
+		.Add(green_slider)
+		.Add(blue_slider)
+		.SetInsets(B_USE_SMALL_INSETS)
+		.End();
 }
 
 ColorBalanceManipulatorView::~ColorBalanceManipulatorView()

--- a/addons/AddOns/Working/ColorBalanceAddOn/ColorBalance.h
+++ b/addons/AddOns/Working/ColorBalanceAddOn/ColorBalance.h
@@ -79,7 +79,7 @@ BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
 void		Reset(Selection*);
 void		SetPreviewBitmap(BBitmap*);
 char*		ReturnHelpString() { return "Use the sliders to adjust the color balance."; }
-char*		ReturnName() { return "Color Balance"; }
+char*		ReturnName() { return "Color balance"; }
 
 ManipulatorSettings*	ReturnSettings();
 BView*	MakeConfigurationView(const BMessenger& target);

--- a/addons/AddOns/Working/ColorReducer/Reducer.cpp
+++ b/addons/AddOns/Working/ColorReducer/Reducer.cpp
@@ -8,13 +8,14 @@
  */
 #include <Bitmap.h>
 #include <ClassInfo.h>
+#include <LayoutBuilder.h>
 #include <Menu.h>
-#include <PopUpMenu.h>
 #include <MenuField.h>
 #include <MenuItem.h>
-#include <StringView.h>
+#include <PopUpMenu.h>
 #include <Screen.h>
 #include <StatusBar.h>
+#include <StringView.h>
 #include <stdio.h>
 #include <string.h>
 #include <Window.h>
@@ -30,7 +31,7 @@
 extern "C" {
 #endif
 	char name[255] = "Reducer…";
-	char menu_help_string[255] = "Starts adjusting the image brightness.";
+	char menu_help_string[255] = "Reduces the number of used colors to a specified maximum.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = COLOR_ADD_ON;
 #ifdef __cplusplus
@@ -273,7 +274,6 @@ ReducerManipulatorView::ReducerManipulatorView(ReducerManipulator *manip,
 {
 	target = t;
 	manipulator = manip;
-	int32 label_width = StringWidth("Palette Mode")+10;	// longest label
 
 	BMenu *dither_menu = new BPopUpMenu("SELECT");
 
@@ -294,11 +294,8 @@ ReducerManipulatorView::ReducerManipulatorView(ReducerManipulator *manip,
 	message->AddInt32("dither_mode",N_CANDIDATE_DITHER);
 	dither_menu->AddItem(new BMenuItem("N-Candidate",message));
 
-	dither_mode_menu_field = new BMenuField(BRect(4, 4, label_width+StringWidth("Floyd-Steinberg EDD")+60,24),
-		"dither_mode_menu_field", "Dither mode", dither_menu);
-	dither_mode_menu_field->SetDivider(label_width);
-	AddChild(dither_mode_menu_field);
-
+	dither_mode_menu_field = new BMenuField(
+		"dither_mode_menu_field", "Dither mode:", dither_menu);
 
 	BMenu *size_menu = new BPopUpMenu("SELECT");	// TODO: Find how initialized...
 
@@ -334,13 +331,7 @@ ReducerManipulatorView::ReducerManipulatorView(ReducerManipulator *manip,
 	message->AddInt32("palette_size",256);
 	size_menu->AddItem(new BMenuItem("256",message));
 
-	BRect frame = dither_mode_menu_field->Frame();
-	frame.OffsetBy(0,frame.Height()+4);
-
-	palette_size_menu_field = new BMenuField(frame, "palette_size_menu_field", "Palette size", size_menu);
-	palette_size_menu_field->SetDivider(label_width);
-	AddChild(palette_size_menu_field);
-
+	palette_size_menu_field = new BMenuField("palette_size_menu_field", "Palette size:", size_menu);
 
 	BMenu *mode_menu = new BPopUpMenu("SELECT");
 
@@ -352,25 +343,28 @@ ReducerManipulatorView::ReducerManipulatorView(ReducerManipulator *manip,
 	message->AddInt32("palette_mode",GLA_PALETTE);
 	mode_menu->AddItem(new BMenuItem("GLA palette",message));
 
-	frame.OffsetBy(0,frame.Height()+4);
-
-	palette_mode_menu_field = new BMenuField(frame, "palette_mode_menu_field", "Palette mode", mode_menu);
-	palette_mode_menu_field->SetDivider(label_width);
-	AddChild(palette_mode_menu_field);
+	palette_mode_menu_field = new BMenuField("palette_mode_menu_field", "Palette mode:", mode_menu);
 
 	dither_menu->ItemAt(settings.dither_mode)->SetMarked(true);
 	size_menu->ItemAt(size_menu->CountItems()-1)->SetMarked(true);	// slight hack...
 	mode_menu->ItemAt(settings.palette_mode)->SetMarked(true);
 	
-	frame.OffsetBy(10,frame.Height()+8);
-	busy = new BStringView(frame, "busy", "Reducing in progress");
-	busy->SetFontSize(16);
+	busy = new BStringView("busy", "Reducing in progress");
 	busy->SetHighColor(128, 0, 0);
 	busy->SetViewColor(ViewColor());
 	busy->Hide();
-	AddChild(busy);
 
-	ResizeTo(palette_mode_menu_field->Frame().Width(), frame.bottom + 4);
+	BLayoutBuilder::Group<>(this, B_VERTICAL)
+		.Add(dither_mode_menu_field)
+		.Add(palette_size_menu_field)
+		.Add(palette_mode_menu_field)
+		.AddGroup(B_HORIZONTAL)
+			.AddGlue()
+			.Add(busy)
+			.AddGlue()
+			.End()
+		.SetInsets(B_USE_SMALL_INSETS)
+		.End();
 }
 
 

--- a/addons/AddOns/Working/ColorSeparator/ColorSeparator.cpp
+++ b/addons/AddOns/Working/ColorSeparator/ColorSeparator.cpp
@@ -9,10 +9,11 @@
 #include <Bitmap.h>
 #include <CheckBox.h>
 #include <ClassInfo.h>
+#include <LayoutBuilder.h>
 #include <Menu.h>
-#include <PopUpMenu.h>
 #include <MenuField.h>
 #include <MenuItem.h>
+#include <PopUpMenu.h>
 #include <StatusBar.h>
 #include <string.h>
 #include <Window.h>
@@ -26,8 +27,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-	char name[255] = "ColorSeparator…";
-	char menu_help_string[255] = "Starts adjusting the image saturation.";
+	char name[255] = "Color separator…";
+	char menu_help_string[255] = "Extracts the Cyan, Magenta, Yellow or Key/Black components for printing.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = COLOR_ADD_ON;
 #ifdef __cplusplus
@@ -206,7 +207,7 @@ void ColorSeparatorManipulator::ChangeSettings(ManipulatorSettings *s)
 
 char* ColorSeparatorManipulator::ReturnName()
 {
-	return "ColorSeparator";
+	return "Color separator";
 }
 
 char* ColorSeparatorManipulator::ReturnHelpString()
@@ -244,13 +245,14 @@ ColorSeparatorManipulatorView::ColorSeparatorManipulatorView(ColorSeparatorManip
 	message->AddInt32("value",SHOW_BLACK);
 	cmyk_menu->AddItem(new BMenuItem("blacK",message));
 
-	cmyk_menu_field = new BMenuField(BRect(4,4,StringWidth("Select C-M-Y-K:")+StringWidth("Magenta")+60,24),
+	cmyk_menu_field = new BMenuField(
 		"cmyk_menu_field","Select C-M-Y-K:",cmyk_menu);
-	AddChild(cmyk_menu_field);
-	cmyk_menu_field->SetDivider(StringWidth("Select C-M-Y-K:")+20);
 	cmyk_menu->ItemAt(settings.mode)->SetMarked(true);
 
-	ResizeTo(cmyk_menu_field->Bounds().Width()+8,cmyk_menu_field->Frame().bottom+4);
+	BLayoutBuilder::Group<>(this, B_VERTICAL)
+		.Add(cmyk_menu_field)
+		.SetInsets(B_USE_SMALL_INSETS)
+		.End();
 }
 
 

--- a/addons/AddOns/Working/Contrast/Contrast.cpp
+++ b/addons/AddOns/Working/Contrast/Contrast.cpp
@@ -7,6 +7,7 @@
  *
  */
 #include <Bitmap.h>
+#include <LayoutBuilder.h>
 #include <Node.h>
 #include <StatusBar.h>
 #include <Slider.h>
@@ -23,7 +24,7 @@
 extern "C" {
 #endif
 	char name[255] = "Contrast…";
-	char menu_help_string[255] = "Starts adjusting the image contrast.";
+	char menu_help_string[255] = "Adjusts the contrast.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = COLOR_ADD_ON;
 #ifdef __cplusplus
@@ -411,16 +412,18 @@ ContrastManipulatorView::ContrastManipulatorView(ContrastManipulator *manip,
 	manipulator = manip;
 	started_adjusting = FALSE;
 
-	contrast_slider = new BSlider(BRect(0,0,200,0), "contrast_slider", "Contrast",
+	contrast_slider = new BSlider("contrast_slider", "Contrast:",
 		new BMessage(CONTRAST_ADJUSTING_FINISHED), 0, 255, B_HORIZONTAL,
 		B_TRIANGLE_THUMB);
 	contrast_slider->SetModificationMessage(new BMessage(CONTRAST_ADJUSTED));
 	contrast_slider->SetLimitLabels("Low","High");
-	contrast_slider->ResizeToPreferred();
-	contrast_slider->MoveTo(4,4);
-	AddChild(contrast_slider);
+	contrast_slider->SetHashMarks(B_HASH_MARKS_BOTTOM);
+	contrast_slider->SetHashMarkCount(11);
 
-	ResizeTo(contrast_slider->Bounds().Width()+8,contrast_slider->Bounds().Height()+8);
+	BLayoutBuilder::Group<>(this, B_VERTICAL)
+		.Add(contrast_slider)
+		.SetInsets(B_USE_SMALL_INSETS)
+		.End();	
 }
 
 ContrastManipulatorView::~ContrastManipulatorView()

--- a/addons/AddOns/Working/ContrastManipulatorAddOn/ContrastManipulator.cpp
+++ b/addons/AddOns/Working/ContrastManipulatorAddOn/ContrastManipulator.cpp
@@ -16,8 +16,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-	char name[255] = "Stretch Histogram";
-	char menu_help_string[255] = "Improves the contrast of the active layer by stretching its histogram.";
+	char name[255] = "Stretch histogram";
+	char menu_help_string[255] = "Improves the contrast by stretching its histogram.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = COLOR_ADD_ON;
 #ifdef __cplusplus

--- a/addons/AddOns/Working/DispersionAddOn/DispersionAddOn.cpp
+++ b/addons/AddOns/Working/DispersionAddOn/DispersionAddOn.cpp
@@ -23,7 +23,7 @@
 extern "C" {
 #endif
 	char name[255] = "Dispersion";
-	char menu_help_string[255] = "Changes pixel positions randomly a little bit.";
+	char menu_help_string[255] = "Randomly moves pixels a bit.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = EFFECT_FILTER_ADD_ON;
 #ifdef __cplusplus

--- a/addons/AddOns/Working/EdgeDetector/DetectEdges.cpp
+++ b/addons/AddOns/Working/EdgeDetector/DetectEdges.cpp
@@ -19,8 +19,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-	char name[255] = "Detects Edges";
-	char menu_help_string[255] = "Detects the edges in the image.";
+	char name[255] = "Detect edges";
+	char menu_help_string[255] = "Detects edges in the image.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = SHARPEN_FILTER_ADD_ON;
 #ifdef __cplusplus
@@ -109,7 +109,7 @@ BBitmap* DetectEdgesManipulator::ManipulateBitmap(BBitmap *original,Selection *s
 
 char* DetectEdgesManipulator::ReturnName()
 {
-	return "Detect Edges";
+	return "Detect edges";
 }
 
 

--- a/addons/AddOns/Working/EmbossAddOn/EmbossAddOn.cpp
+++ b/addons/AddOns/Working/EmbossAddOn/EmbossAddOn.cpp
@@ -20,7 +20,7 @@
 extern "C" {
 #endif
 	char name[255] = "Emboss";
-	char menu_help_string[255] = "Creates an emboss effect on the active layer.";
+	char menu_help_string[255] = "Creates an emboss effect.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = EFFECT_FILTER_ADD_ON;
 #ifdef __cplusplus

--- a/addons/AddOns/Working/EnhanceEdges/EnhanceEdges.cpp
+++ b/addons/AddOns/Working/EnhanceEdges/EnhanceEdges.cpp
@@ -19,7 +19,7 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-	char name[255] = "Enhance Edges";
+	char name[255] = "Enhance edges";
 	char menu_help_string[255] = "Enhances the edges in the image.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = SHARPEN_FILTER_ADD_ON;
@@ -115,7 +115,7 @@ BBitmap* EnhanceEdgesManipulator::ManipulateBitmap(BBitmap *original,Selection *
 
 char* EnhanceEdgesManipulator::ReturnName()
 {
-	return "Enhance Edges";
+	return "Enhance edges";
 }
 
 

--- a/addons/AddOns/Working/GaussianBlur/GaussianBlur.cpp
+++ b/addons/AddOns/Working/GaussianBlur/GaussianBlur.cpp
@@ -7,6 +7,7 @@
  *
  */
 #include <Bitmap.h>
+#include <LayoutBuilder.h>
 #include <StatusBar.h>
 #include <stdio.h>
 #include <StopWatch.h>
@@ -25,8 +26,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-	char name[255] = "Gaussian Blur…";
-	char menu_help_string[255] = "Starts making gaussian blur to the image.";
+	char name[255] = "Gaussian blur…";
+	char menu_help_string[255] = "Adds a gaussian blur to the image.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = COLOR_ADD_ON;
 #ifdef __cplusplus
@@ -262,7 +263,7 @@ void GaussianBlurManipulator::ChangeSettings(ManipulatorSettings *s)
 
 char* GaussianBlurManipulator::ReturnName()
 {
-	return "Gaussian Blur";
+	return "Gaussian blur";
 }
 
 char* GaussianBlurManipulator::ReturnHelpString()
@@ -282,15 +283,17 @@ GaussianBlurManipulatorView::GaussianBlurManipulatorView(GaussianBlurManipulator
 	manipulator = manip;
 	started_adjusting = FALSE;
 
-	blur_slider = new BSlider(BRect(0,0,200,0), "blur_slider", "Blur size",
+	blur_slider = new BSlider("blur_slider", "Blur size:",
 		new BMessage(BLUR_ADJUSTING_FINISHED), 0, 2000, B_HORIZONTAL,
 		B_TRIANGLE_THUMB);
 	blur_slider->SetLimitLabels("Small","Large");
-	blur_slider->ResizeToPreferred();
-	blur_slider->MoveTo(4,4);
-	AddChild(blur_slider);
+	blur_slider->SetHashMarks(B_HASH_MARKS_BOTTOM);
+	blur_slider->SetHashMarkCount(11);
 
-	ResizeTo(blur_slider->Bounds().Width()+8,blur_slider->Bounds().Height()+8);
+	BLayoutBuilder::Group<>(this, B_VERTICAL)
+		.Add(blur_slider)
+		.SetInsets(B_USE_SMALL_INSETS)
+		.End();
 }
 
 GaussianBlurManipulatorView::~GaussianBlurManipulatorView()

--- a/addons/AddOns/Working/Interference/Interference.cpp
+++ b/addons/AddOns/Working/Interference/Interference.cpp
@@ -26,7 +26,7 @@
 extern "C" {
 #endif
 	char name[255] = "Interference…";
-	char menu_help_string[255] = "Makes an interference-pattern on the active layer.";
+	char menu_help_string[255] = "Creates an interference-pattern.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = DISTORT_ADD_ON;
 #ifdef __cplusplus

--- a/addons/AddOns/Working/Makefile
+++ b/addons/AddOns/Working/Makefile
@@ -1,4 +1,4 @@
-SUBDIRS := AdaptiveHistogramEqualization AntiDitherer BlurAddOn \
+SUBDIRS := AdaptiveHistogramEqualization AntiDitherer BlurAddOn Brightness \
 ColorBalanceAddOn ColorReducer ColorSeparator Contrast ContrastManipulatorAddOn \
 DispersionAddOn EdgeDetector EmbossAddOn EnhanceEdges GaussianBlur \
 GrayscaleAddOn Halftone Interference MarbleTexturer NegativeAddOn \

--- a/addons/AddOns/Working/OilAddOn/OilAddOn.cpp
+++ b/addons/AddOns/Working/OilAddOn/OilAddOn.cpp
@@ -22,7 +22,7 @@
 extern "C" {
 #endif
 	char name[255] = "Oil";
-	char menu_help_string[255] = "Makes an \"oil\" effect on the active layer.";
+	char menu_help_string[255] = "Creates an \"oil\" effect.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = EFFECT_FILTER_ADD_ON;
 #ifdef __cplusplus

--- a/addons/AddOns/Working/PolarMapper/PolarMapper.cpp
+++ b/addons/AddOns/Working/PolarMapper/PolarMapper.cpp
@@ -22,8 +22,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-	char name[255] = "LogPolar Mapper";
-	char menu_help_string[255] = "Maps image to it's polar coordinate representation.";
+	char name[255] = "Polar mapper";
+	char menu_help_string[255] = "Maps image to its polar coordinate representation.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = EFFECT_FILTER_ADD_ON;
 #ifdef __cplusplus

--- a/addons/AddOns/Working/PolarMapper/PolarMapper.h
+++ b/addons/AddOns/Working/PolarMapper/PolarMapper.h
@@ -21,7 +21,7 @@ public:
 
 BBitmap*	ManipulateBitmap(BBitmap*,Selection*,BStatusBar*);
 
-char*		ReturnName() { return "LogPolar Mapper"; }
+char*		ReturnName() { return "Polar mapper"; }
 };
 
 #endif

--- a/addons/AddOns/Working/Saturation/Saturation.cpp
+++ b/addons/AddOns/Working/Saturation/Saturation.cpp
@@ -7,8 +7,9 @@
  *
  */
 #include <Bitmap.h>
-#include <StatusBar.h>
+#include <LayoutBuilder.h>
 #include <Slider.h>
+#include <StatusBar.h>
 #include <string.h>
 #include <Window.h>
 
@@ -22,7 +23,7 @@
 extern "C" {
 #endif
 	char name[255] = "Saturation…";
-	char menu_help_string[255] = "Starts adjusting the image saturation.";
+	char menu_help_string[255] = "Adjust color saturation.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = COLOR_ADD_ON;
 #ifdef __cplusplus
@@ -425,16 +426,18 @@ SaturationManipulatorView::SaturationManipulatorView(SaturationManipulator *mani
 	manipulator = manip;
 	started_adjusting = FALSE;
 
-	saturation_slider = new BSlider(BRect(0,0,200,0), "saturation_slider",
-		"Saturation", new BMessage(SATURATION_ADJUSTING_FINISHED), 0, 255,
+	saturation_slider = new BSlider("saturation_slider",
+		"Saturation:", new BMessage(SATURATION_ADJUSTING_FINISHED), 0, 255,
 		B_HORIZONTAL, B_TRIANGLE_THUMB);
 	saturation_slider->SetModificationMessage(new BMessage(SATURATION_ADJUSTED));
 	saturation_slider->SetLimitLabels("Low","High");
-	saturation_slider->ResizeToPreferred();
-	saturation_slider->MoveTo(4,4);
-	AddChild(saturation_slider);
+	saturation_slider->SetHashMarks(B_HASH_MARKS_BOTTOM);
+	saturation_slider->SetHashMarkCount(11);
 
-	ResizeTo(saturation_slider->Bounds().Width()+8,saturation_slider->Bounds().Height()+8);
+	BLayoutBuilder::Group<>(this, B_VERTICAL)
+		.Add(saturation_slider)
+		.SetInsets(B_USE_SMALL_INSETS)
+		.End();
 }
 
 SaturationManipulatorView::~SaturationManipulatorView()

--- a/addons/AddOns/Working/Sharpness/Sharpness.cpp
+++ b/addons/AddOns/Working/Sharpness/Sharpness.cpp
@@ -7,9 +7,10 @@
  *
  */
 #include <Bitmap.h>
+#include <LayoutBuilder.h>
+#include <Slider.h>
 #include <StatusBar.h>
 #include <StopWatch.h>
-#include <Slider.h>
 #include <string.h>
 #include <Window.h>
 
@@ -24,7 +25,7 @@
 extern "C" {
 #endif
 	char name[255] = "Sharpness…";
-	char menu_help_string[255] = "Starts adjusting the image sharpness.";
+	char menu_help_string[255] = "Adjust the sharpness.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = COLOR_ADD_ON;
 #ifdef __cplusplus
@@ -416,26 +417,26 @@ SharpnessManipulatorView::SharpnessManipulatorView(SharpnessManipulator *manip,
 	manipulator = manip;
 	started_adjusting = FALSE;
 
-	sharpness_slider = new BSlider(BRect(0,0,200,0), "sharpness_slider",
-		"Sharpness", new BMessage(SHARPNESS_ADJUSTING_FINISHED), 0, 255,
+	sharpness_slider = new BSlider("sharpness_slider",
+		"Sharpness:", new BMessage(SHARPNESS_ADJUSTING_FINISHED), 0, 255,
 		B_HORIZONTAL, B_TRIANGLE_THUMB);
 	sharpness_slider->SetModificationMessage(new BMessage(SHARPNESS_ADJUSTED));
 	sharpness_slider->SetLimitLabels("Blurred","Sharp");
-	sharpness_slider->ResizeToPreferred();
-	sharpness_slider->MoveTo(4,4);
-	AddChild(sharpness_slider);
+	sharpness_slider->SetHashMarks(B_HASH_MARKS_BOTTOM);
+	sharpness_slider->SetHashMarkCount(11);
 
-	BRect slider_frame = sharpness_slider->Frame();
-	slider_frame.OffsetBy(0,slider_frame.Height()+4);
-
-	blur_size_slider = new BSlider(slider_frame, "blur_size_slider",
-		"Effect strength", new BMessage(BLUR_ADJUSTING_FINISHED), 1, 50,
+	blur_size_slider = new BSlider("blur_size_slider",
+		"Effect strength:", new BMessage(BLUR_ADJUSTING_FINISHED), 1, 50,
 		B_HORIZONTAL, B_TRIANGLE_THUMB);
-	blur_size_slider->SetLimitLabels("Small","Big");
-	blur_size_slider->ResizeToPreferred();
-	AddChild(blur_size_slider);
+	blur_size_slider->SetLimitLabels("Low","High");
+	blur_size_slider->SetHashMarks(B_HASH_MARKS_BOTTOM);
+	blur_size_slider->SetHashMarkCount(11);
 
-	ResizeTo(sharpness_slider->Bounds().Width()+8,blur_size_slider->Frame().bottom+4);
+	BLayoutBuilder::Group<>(this, B_VERTICAL, B_USE_ITEM_SPACING)
+		.Add(sharpness_slider)
+		.Add(blur_size_slider)
+		.SetInsets(B_USE_SMALL_INSETS)
+		.End();
 }
 
 SharpnessManipulatorView::~SharpnessManipulatorView()

--- a/addons/AddOns/Working/Threshold/Threshold.cpp
+++ b/addons/AddOns/Working/Threshold/Threshold.cpp
@@ -14,6 +14,7 @@
 */
 
 #include <Bitmap.h>
+#include <LayoutBuilder.h>
 #include <Node.h>
 #include <StatusBar.h>
 #include <stdio.h>
@@ -31,7 +32,7 @@
 extern "C" {
 #endif
 	char name[255] = "Threshold…";
-	char menu_help_string[255] = "Starts thresholding the image.";
+	char menu_help_string[255] = "Show only pixels of a specified threshold.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = COLOR_ADD_ON;
 #ifdef __cplusplus
@@ -434,11 +435,12 @@ ThresholdManipulatorView::ThresholdManipulatorView(ThresholdManipulator *manip,
 	manipulator = manip;
 	started_adjusting = FALSE;
 
-	threshold_control = new ThresholdView(BRect(0,0,0,0),new BMessage(THRESHOLD_ADJUSTING_FINISHED));
-	threshold_control->MoveTo(4,4);
-	AddChild(threshold_control);
+	threshold_control = new ThresholdView(new BMessage(THRESHOLD_ADJUSTING_FINISHED));
 
-	ResizeTo(threshold_control->Bounds().Width()+8,threshold_control->Bounds().Height()+8);
+	BLayoutBuilder::Group<>(this, B_VERTICAL)
+		.Add(threshold_control)
+		.SetInsets(B_USE_SMALL_INSETS)
+		.End();
 }
 
 

--- a/addons/AddOns/Working/Threshold/ThresholdView.h
+++ b/addons/AddOns/Working/Threshold/ThresholdView.h
@@ -16,7 +16,7 @@
 
 class ThresholdView : public BControl {
 public:
-		ThresholdView(BRect,BMessage*);
+		ThresholdView(BMessage*);
 
 void	AttachedToWindow();
 

--- a/addons/AddOns/Working/TwirlAddOn/Twirl.cpp
+++ b/addons/AddOns/Working/TwirlAddOn/Twirl.cpp
@@ -8,8 +8,9 @@
  */
 #include <Bitmap.h>
 #include <math.h>
-#include <StatusBar.h>
+#include <LayoutBuilder.h>
 #include <Slider.h>
+#include <StatusBar.h>
 #include <Window.h>
 
 #define PI M_PI
@@ -26,7 +27,7 @@
 extern "C" {
 #endif
 	char name[255] = "Twirl…";
-	char menu_help_string[255] = "Starts twirling the active layer.";
+	char menu_help_string[255] = "Twirls the active layer.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = DISTORT_ADD_ON;
 #ifdef __cplusplus
@@ -498,28 +499,27 @@ TwirlManipulatorView::TwirlManipulatorView(BRect rect,TwirlManipulator *manip,
 	target = new BMessenger(t);
 	preview_started = FALSE;
 
-	twirl_radius_slider = new BSlider(BRect(0,0,150,0), "twirl_radius_slider",
-		"Twirl size", new BMessage(TWIRL_RADIUS_CHANGED), 10, 1000,
+	twirl_radius_slider = new BSlider("twirl_radius_slider",
+		"Twirl size:", new BMessage(TWIRL_RADIUS_CHANGED), 10, 1000,
 		B_HORIZONTAL, B_TRIANGLE_THUMB);
 	twirl_radius_slider->SetLimitLabels("Small","Big");
 	twirl_radius_slider->SetModificationMessage(new BMessage(TWIRL_RADIUS_ADJUSTING_STARTED));
-	twirl_radius_slider->ResizeToPreferred();
-	twirl_radius_slider->MoveTo(4,4);
+	twirl_radius_slider->SetHashMarks(B_HASH_MARKS_BOTTOM);
+	twirl_radius_slider->SetHashMarkCount(11);
 
-	BRect frame = twirl_radius_slider->Frame();
-	frame.OffsetBy(0,frame.Height()+4);
-
-	twirl_amount_slider = new BSlider(frame, "twirl_amount_slider",
-		"Twirl direction", new BMessage(TWIRL_AMOUNT_CHANGED), MIN_TWIRL_AMOUNT,
+	twirl_amount_slider = new BSlider("twirl_amount_slider",
+		"Twirl direction:", new BMessage(TWIRL_AMOUNT_CHANGED), MIN_TWIRL_AMOUNT,
 		MAX_TWIRL_AMOUNT, B_HORIZONTAL, B_TRIANGLE_THUMB);
 	twirl_amount_slider->SetLimitLabels("Left","Right");
 	twirl_amount_slider->SetModificationMessage(new BMessage(TWIRL_AMOUNT_ADJUSTING_STARTED));
-	twirl_amount_slider->ResizeToPreferred();
+	twirl_amount_slider->SetHashMarks(B_HASH_MARKS_BOTTOM);
+	twirl_amount_slider->SetHashMarkCount(11);
 
-	AddChild(twirl_radius_slider);
-	AddChild(twirl_amount_slider);
-
-	ResizeTo(twirl_amount_slider->Frame().Width()+8,twirl_amount_slider->Frame().bottom+4);
+	BLayoutBuilder::Group<>(this, B_VERTICAL, B_USE_ITEM_SPACING)
+		.Add(twirl_radius_slider)
+		.Add(twirl_amount_slider)
+		.SetInsets(B_USE_SMALL_INSETS)
+		.End();
 }
 
 

--- a/addons/AddOns/Working/WaveAddOn/Wave.cpp
+++ b/addons/AddOns/Working/WaveAddOn/Wave.cpp
@@ -8,9 +8,10 @@
  */
 #include <Bitmap.h>
 #include <math.h>
+#include <LayoutBuilder.h>
+#include <Slider.h>
 #include <StatusBar.h>
 #include <StopWatch.h>
-#include <Slider.h>
 #include <Window.h>
 
 #include "AddOns.h"
@@ -27,7 +28,7 @@
 extern "C" {
 #endif
 	char name[255] = "Wave…";
-	char menu_help_string[255] = "Starts waving the active layer.";
+	char menu_help_string[255] = "Adds a wave to the active layer.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = DISTORT_ADD_ON;
 #ifdef __cplusplus
@@ -964,28 +965,27 @@ WaveManipulatorView::WaveManipulatorView(BRect rect,WaveManipulator *manip,
 	target = new BMessenger(t);
 	preview_started = FALSE;
 
-	wave_length_slider = new BSlider(BRect(0,0,150,0), "wave_length_slider",
-		"Wave length", new BMessage(WAVE_LENGTH_CHANGED), MIN_WAVE_LENGTH,
+	wave_length_slider = new BSlider("wave_length_slider",
+		"Wave length:", new BMessage(WAVE_LENGTH_CHANGED), MIN_WAVE_LENGTH,
 		MAX_WAVE_LENGTH, B_HORIZONTAL, B_TRIANGLE_THUMB);
 	wave_length_slider->SetLimitLabels("Short","Long");
 	wave_length_slider->SetModificationMessage(new BMessage(WAVE_LENGTH_ADJUSTING_STARTED));
-	wave_length_slider->ResizeToPreferred();
-	wave_length_slider->MoveTo(4,4);
+	wave_length_slider->SetHashMarks(B_HASH_MARKS_BOTTOM);
+	wave_length_slider->SetHashMarkCount(11);
 
-	BRect frame = wave_length_slider->Frame();
-	frame.OffsetBy(0,frame.Height()+4);
-
-	wave_amount_slider = new BSlider(frame, "wave_amount_slider", "Wave strength",
+	wave_amount_slider = new BSlider("wave_amount_slider", "Wave strength:",
 		new BMessage(WAVE_AMOUNT_CHANGED), MIN_WAVE_AMOUNT, MAX_WAVE_AMOUNT,
 		B_HORIZONTAL, B_TRIANGLE_THUMB);
 	wave_amount_slider->SetLimitLabels("Mild","Strong");
 	wave_amount_slider->SetModificationMessage(new BMessage(WAVE_AMOUNT_ADJUSTING_STARTED));
-	wave_amount_slider->ResizeToPreferred();
+	wave_amount_slider->SetHashMarks(B_HASH_MARKS_BOTTOM);
+	wave_amount_slider->SetHashMarkCount(11);
 
-	AddChild(wave_length_slider);
-	AddChild(wave_amount_slider);
-
-	ResizeTo(wave_amount_slider->Frame().Width()+8,wave_amount_slider->Frame().bottom+4);
+	BLayoutBuilder::Group<>(this, B_VERTICAL, B_USE_ITEM_SPACING)
+		.Add(wave_length_slider)
+		.Add(wave_amount_slider)
+		.SetInsets(B_USE_SMALL_INSETS)
+		.End();
 }
 
 

--- a/addons/AddOns/Working/WoodRelief/Wood.cpp
+++ b/addons/AddOns/Working/WoodRelief/Wood.cpp
@@ -21,8 +21,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-	char name[255] = "PerlinWood";
-	char menu_help_string[255] = "Woods the image using perlin noise function.";
+	char name[255] = "Wood";
+	char menu_help_string[255] = "Puts a wood-like texture over the image.";
 	int32 add_on_api_version = ADD_ON_API_VERSION;
 	add_on_types add_on_type = EFFECT_FILTER_ADD_ON;
 #ifdef __cplusplus
@@ -86,7 +86,7 @@ BBitmap* WoodManipulator::ManipulateBitmap(BBitmap *original,Selection *selectio
 
 char* WoodManipulator::ReturnName()
 {
-	return "PerlinWood";
+	return "Wood";
 }
 
 


### PR DESCRIPTION
* Applied some layout management to all the add-ons.
* Added hash marks to BSliders, use consistent low/high labels
  where possible.
* Sentence casing add-on names.
* Improved/corrected status bar help texts. Among other things, all
  add-ons work on the active layer only, so no need to point that out.
* Threshold add-on:
  Fixed some drawing errors. There's still an issue when the threshold
  line is dragged to the far right. For some reason the histogramBitmap
  seems to be 4 pixels short. I'll have to leave that one to a real
  coder...
* Renamed PerlinWood to Wood.
* Added missing Brightness add-on to the Makefile.