### PR TITLE
Fixes for out-of-range Bitmap references

### DIFF
--- a/addons/UtilityClasses/ImageProcessingLibrary.cpp
+++ b/addons/UtilityClasses/ImageProcessingLibrary.cpp
@@ -4,7 +4,6 @@
  *
  * Authors:
  * 		Heikki Suhonen <heikki.suhonen@gmail.com>
- *	Array overflow fix 2017/7/18  Pete G.
  */
 #include <OS.h>
 #include <stdio.h>

--- a/addons/UtilityClasses/ImageProcessingLibrary.cpp
+++ b/addons/UtilityClasses/ImageProcessingLibrary.cpp
@@ -4,7 +4,7 @@
  *
  * Authors:
  * 		Heikki Suhonen <heikki.suhonen@gmail.com>
- *
+ *	Array overflow fix 2017/7/18  Pete G.
  */
 #include <OS.h>
 #include <stdio.h>
@@ -281,7 +281,7 @@ void ImageProcessingLibrary::filter_1d_and_rotate_clockwise(int32 *s_bits,int32 
 
 		uint32 *target_array_position = target_array;
 		for (int32 x = left;x<=right;x++) {
-			*(d_bits + (d_bpr-y) + x*d_bpr) = *target_array_position++;
+			*(d_bits + (d_bpr-1-y) + x*d_bpr) = *target_array_position++;
 		}
 	}
 
@@ -297,7 +297,6 @@ void ImageProcessingLibrary::filter_1d_and_rotate_counterclockwise(int32 *s_bits
 	uint32 *target_array = new uint32[width];
 
 
-	s_bits++;	// TODO: Why this?
 	for (int32 y=top;y<=bottom;++y) {
 		uint32 *source_array_position = source_array;
 		for (int32 dx = 0;dx<kernel_radius;++dx) {

--- a/artpaint/viewmanipulators/ScaleManipulator.cpp
+++ b/artpaint/viewmanipulators/ScaleManipulator.cpp
@@ -114,7 +114,8 @@ BBitmap* ScaleManipulator::ManipulateBitmap(ManipulatorSettings *set,
 														*(source_bits + (int32)ceil(accumulation)),
 														(uint32)(32768*(ceil(accumulation)-accumulation)));
 
-					if (accumulation < source_pxpr-1) accumulation += diff;
+					accumulation += diff;
+					if (accumulation > source_pxpr-1) accumulation = source_pxpr-1;
 				}
 				source_bits += source_pxpr;
 				if ((y%10 == 0) && (status_bar != NULL)) {


### PR DESCRIPTION
Nobody seems to get Bitmap dimensions right!  I happened to be working with a power-of-2 sized image, and hit _two_ separate exceptions!  GaussianBlur and Sharpness both crashed (they use the same code), and trying to scale up x 2 did the same.  Both seem to be in Heikke's original code (but don't crash BeOS).  They are both only off-by-one accesses, and don't even trigger a Haiku exception every time.  They were a pain to track down, but I think the fixes are correct.

(In ScaleManipulator.cpp, I also changed "..._bpr" variables to "..._pxpr", because they are  not bytes-per-row, but 32-bit pixel counts.)
