### PR TITLE
Fix crop window number controls

### DIFF
--- a/artpaint/viewmanipulators/CropManipulator.cpp
+++ b/artpaint/viewmanipulators/CropManipulator.cpp
@@ -389,10 +389,12 @@ CropManipulatorView::CropManipulatorView(CropManipulator* manipulator,
 		.End()
 	);
 
-	fTopCrop->SetValue(0);
-	fLeftCrop->SetValue(0);
-	fRightCrop->SetValue(0);
-	fBottomCrop->SetValue(0);
+	CropManipulatorSettings* settings
+		= (CropManipulatorSettings*)manipulator->ReturnSettings();
+	fTopCrop->SetValue(settings->top);
+	fLeftCrop->SetValue(settings->left);
+	fRightCrop->SetValue(settings->right);
+	fBottomCrop->SetValue(settings->bottom);
 }
 
 


### PR DESCRIPTION
The Control Window for the Crop operation was rather messed up.  When a crop was initiated, it only showed '0' for all the bounds.  When it did display them, only the leftmost digits were visible -- very confusing for large images!  Fixing the first problem has cured the second...