### PR TITLE
ArtPaint: change POWERPC/INTEL defines to use BYTE_ORDER == BIG_ENDIAN

### DIFF
--- a/addons/AddOns/Working/Interference/Interference.h
+++ b/addons/AddOns/Working/Interference/Interference.h
@@ -120,7 +120,7 @@ inline 	asm	float reciprocal_of_square_root(register float number)
 	frsqrte		fp1,number;	// Estimates reciprocal of square-root
 	blr
 }
-#elif __INTEL__
+#else
 float reciprocal_of_square_root(register float number)
 {
 	return 1.0 / sqrt(number);

--- a/addons/AddOns/Working/TwirlAddOn/Twirl.cpp
+++ b/addons/AddOns/Working/TwirlAddOn/Twirl.cpp
@@ -338,9 +338,9 @@ int32 TwirlManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRe
 		 		for (int32 x=0;x<source_bpr;x += last_calculated_resolution) {
 					real_x = x-cx;
 					real_y = y-cy;
-					#ifdef __POWERPC__
+					#if BYTE_ORDER == BIG_ENDIAN
 					distance = 1.0/reciprocal_of_square_root(real_x*real_x + real_y*real_y);
-					#elif __INTEL__
+					#else
 //					distance = fsqrt(real_x*real_x + real_y*real_y);
 					distance = sqrt(real_x*real_x + real_y*real_y);
 					#endif
@@ -373,9 +373,9 @@ int32 TwirlManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRe
 		 		for (int32 x=0;x<source_bpr;x += last_calculated_resolution) {
 					real_x = x-cx;
 					real_y = y-cy;
-					#ifdef __POWERPC__
+					#if BYTE_ORDER == BIG_ENDIAN
 					distance = 1.0/reciprocal_of_square_root(real_x*real_x + real_y*real_y);
-					#elif __INTEL__
+					#else
 //					distance = fsqrt(real_x*real_x + real_y*real_y);
 					distance = sqrt(real_x*real_x + real_y*real_y);
 					#endif

--- a/addons/AddOns/Working/TwirlAddOn/Twirl.cpp
+++ b/addons/AddOns/Working/TwirlAddOn/Twirl.cpp
@@ -338,7 +338,7 @@ int32 TwirlManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRe
 		 		for (int32 x=0;x<source_bpr;x += last_calculated_resolution) {
 					real_x = x-cx;
 					real_y = y-cy;
-					#if BYTE_ORDER == BIG_ENDIAN
+					#ifdef __POWERPC__
 					distance = 1.0/reciprocal_of_square_root(real_x*real_x + real_y*real_y);
 					#else
 //					distance = fsqrt(real_x*real_x + real_y*real_y);
@@ -373,7 +373,7 @@ int32 TwirlManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRe
 		 		for (int32 x=0;x<source_bpr;x += last_calculated_resolution) {
 					real_x = x-cx;
 					real_y = y-cy;
-					#if BYTE_ORDER == BIG_ENDIAN
+					#ifdef __POWERPC__
 					distance = 1.0/reciprocal_of_square_root(real_x*real_x + real_y*real_y);
 					#else
 //					distance = fsqrt(real_x*real_x + real_y*real_y);

--- a/addons/AddOns/Working/TwirlAddOn/Twirl.h
+++ b/addons/AddOns/Working/TwirlAddOn/Twirl.h
@@ -121,14 +121,14 @@ void	ChangeSettings(TwirlManipulatorSettings *s);
 };
 
 
-#if __POWERPC__
+#ifdef __POWERPC__
 inline 	asm	float reciprocal_of_square_root(register float number)
 {
 	machine		603
 	frsqrte		fp1,number;	// Estimates reciprocal of square-root
 	blr
 }
-#elif __INTEL__
+#else
 // This is very slow.
 inline float reciprocal_of_square_root(register float number)
 {

--- a/addons/AddOns/Working/WaveAddOn/Wave.cpp
+++ b/addons/AddOns/Working/WaveAddOn/Wave.cpp
@@ -416,7 +416,7 @@ int32 WaveManipulator::PreviewBitmap(Selection *selection,bool full_quality,BReg
 					if ((real_x != 0) && (real_y != 0)) {
 						// Let's try the inline assemler function for square root estimation.
 						// On intel this does not yet work and the corresponding function is very slow.
-						#if BYTE_ORDER == BIG_ENDIAN
+						#ifdef __POWERPC__
 						one_per_sqrt_x_plus_y = reciprocal_of_square_root(real_x*real_x+real_y*real_y);
 						sqrt_x_plus_y = 1.0/one_per_sqrt_x_plus_y;
 						#else
@@ -475,7 +475,7 @@ int32 WaveManipulator::PreviewBitmap(Selection *selection,bool full_quality,BReg
 					if (selection->ContainsPoint(x,y) == TRUE) {
 						if ((real_x != 0) && (real_y != 0)) {
 							// Let's try the inline assemler function for square root estimation
-							#if BYTE_ORDER == BIG_ENDIAN
+							#ifdef __POWERPC__
 							one_per_sqrt_x_plus_y = reciprocal_of_square_root(real_x*real_x+real_y*real_y);
 							sqrt_x_plus_y = 1.0/one_per_sqrt_x_plus_y;
 							#else

--- a/addons/AddOns/Working/WaveAddOn/Wave.cpp
+++ b/addons/AddOns/Working/WaveAddOn/Wave.cpp
@@ -416,10 +416,10 @@ int32 WaveManipulator::PreviewBitmap(Selection *selection,bool full_quality,BReg
 					if ((real_x != 0) && (real_y != 0)) {
 						// Let's try the inline assemler function for square root estimation.
 						// On intel this does not yet work and the corresponding function is very slow.
-						#if __POWERPC__
+						#if BYTE_ORDER == BIG_ENDIAN
 						one_per_sqrt_x_plus_y = reciprocal_of_square_root(real_x*real_x+real_y*real_y);
 						sqrt_x_plus_y = 1.0/one_per_sqrt_x_plus_y;
-						#elif __INTEL__
+						#else
 //						sqrt_x_plus_y = fsqrt(real_x*real_x+real_y*real_y);
 						sqrt_x_plus_y = sqrt(real_x*real_x+real_y*real_y);
 						one_per_sqrt_x_plus_y = 1.0 / sqrt_x_plus_y;
@@ -475,10 +475,10 @@ int32 WaveManipulator::PreviewBitmap(Selection *selection,bool full_quality,BReg
 					if (selection->ContainsPoint(x,y) == TRUE) {
 						if ((real_x != 0) && (real_y != 0)) {
 							// Let's try the inline assemler function for square root estimation
-							#ifdef __POWERPC__
+							#if BYTE_ORDER == BIG_ENDIAN
 							one_per_sqrt_x_plus_y = reciprocal_of_square_root(real_x*real_x+real_y*real_y);
 							sqrt_x_plus_y = 1.0/one_per_sqrt_x_plus_y;
-							#elif __INTEL__
+							#else
 //							sqrt_x_plus_y = fsqrt(real_x*real_x+real_y*real_y);
 							sqrt_x_plus_y = sqrt(real_x*real_x+real_y*real_y);
 							one_per_sqrt_x_plus_y = 1.0 / sqrt_x_plus_y;

--- a/addons/AddOns/Working/WaveAddOn/Wave.h
+++ b/addons/AddOns/Working/WaveAddOn/Wave.h
@@ -135,7 +135,7 @@ inline 	asm	float reciprocal_of_square_root(register float number)
 	frsqrte		fp1,number;	// Estimates reciprocal of square-root
 	blr
 }
-#elif __INTEL__ || defined(__x86_64__)
+#else
 float reciprocal_of_square_root(register float number)
 {
 	return 1.0 / sqrt(number);

--- a/artpaint/paintwindow/Image.cpp
+++ b/artpaint/paintwindow/Image.cpp
@@ -1251,10 +1251,10 @@ int32 Image::DoRender(BRect area)
 				for (register int32 x=0;x<width;++x) {
 					s = *s_bits;
 					d = *d_bits;
-					#if __POWERPC__
+					#if BYTE_ORDER == BIG_ENDIAN
 					As = FixedAlphaTable[s & 0x000000ff];
 					Ad = full_fixed_alpha - As;
-					#elif __INTEL__
+					#else
 					As = FixedAlphaTable[(s>>24) & 0x000000ff];
 					Ad = full_fixed_alpha - As;
 					#endif
@@ -1410,24 +1410,24 @@ int32 Image::DoRenderPreview(BRect area,int32 resolution)
 					uint32 layer = layer_bits[j][x + y*layer_bprs[j]];
 					register uint32 As;
 					register uint32 Ad;
-					#if __POWERPC__
+					#if BYTE_ORDER == BIG_ENDIAN
 					As = alpha_tables[j][layer & 0x000000ff];
 					Ad = full_fixed_alpha - As;
-					#elif __INTEL__
+					#else
 					As = alpha_tables[j][(layer>>24) & 0x000000ff];
 					Ad = full_fixed_alpha - As;
 					#endif
 
 					uint32 spare_target = 0x00000000;
 
-					#ifdef __POWERPC__
+					#if BYTE_ORDER == BIG_ENDIAN
 					spare_target =	( ( ( (layer >> 24) * As ) +
 								( (target >> 24) * Ad ) ) >> 15 ) << 24;
 					spare_target |=	( ( ( ((layer >> 16) & 0x000000ff) * As ) +
 								( ((target >> 16) & 0x000000ff) * Ad ) ) >> 15 ) << 16;
 					spare_target |=	( ( ( ((layer >> 8) & 0x000000ff) * As ) +
 								( ((target >> 8) & 0x000000ff) * Ad ) ) >> 15 ) << 8;
-					#elif __INTEL__
+					#else
 					spare_target =	( ( ( ((layer >> 16) & 0x000000ff) * As ) +
 								( ((target >> 16) & 0x000000ff) * Ad ) ) >> 15 ) << 16;
 					spare_target |=	( ( ( ((layer >> 8) & 0x000000ff) * As ) +


### PR DESCRIPTION
Change __INTEL__ and __POWERPC__ preprocessor checks to use BYTE_ORDER
== BIG_ENDIAN. This allows more generic support for architectures, and
also fixes alpha compositing issue on x86_64 (and perhaps selection
issue on x86).

Didn't change a couple of places where inline asm is used because that might still be specific to the PowerPC arch, but I changed the elif to just else so everything else besides POWERPC will just fall through.

Fixes #81