### PR TITLE
Open dropped images/project files

### DIFF
--- a/artpaint/application/PaintApplication.cpp
+++ b/artpaint/application/PaintApplication.cpp
@@ -210,6 +210,11 @@ PaintApplication::MessageReceived(BMessage* message)
 			}
 		}	break;
 
+		case B_SIMPLE_DATA:
+		case B_REFS_RECEIVED: {
+			RefsReceived(message);
+		}	break;
+
 		default:
 			BApplication::MessageReceived(message);
 			break;

--- a/artpaint/paintwindow/PaintWindow.cpp
+++ b/artpaint/paintwindow/PaintWindow.cpp
@@ -510,6 +510,11 @@ void
 PaintWindow::MessageReceived(BMessage *message)
 {
 	switch ( message->what ) {
+		case B_SIMPLE_DATA:
+		case B_REFS_RECEIVED: {
+			be_app_messenger.SendMessage(message);
+		}	break;
+
 		case HS_RESIZE_WINDOW_TO_FIT: {
 			// this comes from fMenubar->"Window"->"Resize Window to Fit" and
 			// informs us that we should fit the window to display exactly the


### PR DESCRIPTION
Simply forwards the dropped refs message to the main app.
Addresses #97, though the there mentioned ideas are not completely
trivial to implement. A first step at least.