### PR TITLE
ArtPaint: set proper scroll bar height of Layer window

### DIFF
--- a/artpaint/layers/LayerWindow.cpp
+++ b/artpaint/layers/LayerWindow.cpp
@@ -63,7 +63,8 @@ LayerWindow::LayerWindow(BRect frame)
 
 	scroll_bar = new BScrollBar(BRect(0,0,B_V_SCROLL_BAR_WIDTH-1,100),"layer_window_scroll_bar",list_view,0,0,B_VERTICAL);
 	scroll_bar->MoveTo(list_view->Frame().RightTop()+BPoint(2,0));
-	scroll_bar->ResizeTo(B_V_SCROLL_BAR_WIDTH,100);
+	scroll_bar->ResizeTo(B_V_SCROLL_BAR_WIDTH,
+		frame.Height() - list_view->Frame().top);
 	AddChild(scroll_bar);
 
 	layer_count = 0;


### PR DESCRIPTION
scroll bar of Layer window was set to 100 units in height; now set
the height based on the height of the list view.

I spent some time trying to re-do the Layer window via Layout API, but it was proving to be a challenge.  This was the quickest fix for the scrollbar issue now, but I will consider revisiting this window in the future. 

Fixes #99