### PR TITLE
ArtPaint: lock fImageSizeWindow before checking if it's hidden

### DIFF
--- a/artpaint/paintwindow/PaintWindow.cpp
+++ b/artpaint/paintwindow/PaintWindow.cpp
@@ -109,6 +109,7 @@ PaintWindow::PaintWindow(BRect frame, const char* name, uint32 views,
 	, fImageSavePanel(NULL)
 	, fProjectSavePanel(NULL)
 	, fCurrentHandler(0)
+	, fImageSizeWindow(NULL)
 {
 	sgPaintWindowCount++;
 	SetSizeLimits(500, 10000, 400, 10000);
@@ -396,8 +397,11 @@ void
 PaintWindow::FrameResized(float newWidth, float newHeight)
 {
 	fSettings.ReplaceRect(skFrame, Frame());
-	if (!fImageSizeWindow->IsHidden())
-		fImageSizeWindow->CenterIn(Frame());
+	if (fImageSizeWindow && fImageSizeWindow->Lock()) {
+		if (!fImageSizeWindow->IsHidden())
+			fImageSizeWindow->CenterIn(Frame());
+		fImageSizeWindow->Unlock();
+	}
 }
 
 
@@ -405,8 +409,11 @@ void
 PaintWindow::FrameMoved(BPoint newPosition)
 {
 	fSettings.ReplaceRect(skFrame, Frame());
-	if (!fImageSizeWindow->IsHidden())
-		fImageSizeWindow->CenterIn(Frame());
+	if (fImageSizeWindow && fImageSizeWindow->Lock()) {
+		if (!fImageSizeWindow->IsHidden())
+			fImageSizeWindow->CenterIn(Frame());
+		fImageSizeWindow->Unlock();
+	}
 }
 
 
@@ -506,7 +513,7 @@ PaintWindow::MessageReceived(BMessage *message)
 
 		case HS_RECENT_IMAGE_SIZE: {
 			// This comes from the recent image-size pop-up-list.
-			if (fImageSizeWindow->Lock()) {
+			if (fImageSizeWindow && fImageSizeWindow->Lock()) {
 				fWidthNumberControl->SetValue(message->FindInt32("width"));
 				fHeightNumberControl->SetValue(message->FindInt32("height"));
 				fImageSizeWindow->Unlock();
@@ -917,7 +924,7 @@ PaintWindow::DisplayCoordinates(BPoint point, BPoint reference, bool useReferenc
 
 	if (fSetSizeButton != NULL) {
 		// if the window is in resize mode display dimensions here too
-		if (fImageSizeWindow->Lock()) {
+		if (fImageSizeWindow && fImageSizeWindow->Lock()) {
 			fWidthNumberControl->SetValue(int32(point.x));
 			fHeightNumberControl->SetValue(int32(point.y));
 			fImageSizeWindow->Unlock();


### PR DESCRIPTION
Added lock before checking if fImageSizeWindow IsHidden in both
FrameResized and FrameMoved methods of PaintWindow.  Also added
checks for fImageSizeWindow before all other calls to Lock in
case it's NULL.

Fixes #115