### PR TITLE
ArtPaint: Fixed copy/paste with selection

### DIFF
--- a/artpaint/layers/Layer.cpp
+++ b/artpaint/layers/Layer.cpp
@@ -27,7 +27,7 @@
 
 
 Layer::Layer(BRect frame, int32 id, ImageView* imageView, layer_type type,
-		BBitmap* bitmap)
+		BBitmap* bitmap, BRect* offset)
 	: fLayerData(NULL)
 	, fLayerPreview(NULL)
 	, fLayerId(id)
@@ -72,7 +72,16 @@ Layer::Layer(BRect frame, int32 id, ImageView* imageView, layer_type type,
 			*target_bits++ = color.word;
 
 		if (bitmap && bitmap->IsValid()) {
-			fLayerData->ImportBits(bitmap);
+			uint32 bpr = fLayerData->BytesPerRow();
+			uint32 bmp_offset = 0;
+			if (offset != NULL)
+				bmp_offset = (offset->left * 4) +
+					(offset->top * bpr);
+
+			fLayerData->ImportBits(bitmap->Bits(),
+				bitmap->BitsLength(),
+				bitmap->BytesPerRow(),
+				bmp_offset, B_RGBA32);
 		}
 
 		// create the miniature image for this layer and a semaphore for it

--- a/artpaint/layers/Layer.h
+++ b/artpaint/layers/Layer.h
@@ -58,7 +58,8 @@ public:
 								Layer(BRect frame, int32 id,
 									ImageView* imageView,
 									layer_type type = HS_NORMAL_LAYER,
-									BBitmap* bitmap = NULL);
+									BBitmap* bitmap = NULL,
+									BRect* offset = NULL);
 								~Layer();
 
 			BBitmap*			Bitmap() const { return fLayerData; }

--- a/artpaint/paintwindow/Image.cpp
+++ b/artpaint/paintwindow/Image.cpp
@@ -299,7 +299,9 @@ bool Image::SetImageSize()
 }
 
 
-Layer* Image::AddLayer(BBitmap *bitmap,Layer *next_layer,bool add_to_front,float layer_transparency_coefficient)
+Layer*
+Image::AddLayer(BBitmap *bitmap, Layer *next_layer, bool add_to_front,
+	float layer_transparency_coefficient, BRect* offset)
 {
 	bool create_layer = TRUE;
 	if (layer_list->CountItems() != 0) {
@@ -317,7 +319,8 @@ Layer* Image::AddLayer(BBitmap *bitmap,Layer *next_layer,bool add_to_front,float
 	// add a layer to correct position in the list
 	Layer *new_layer;
 	try {
-		new_layer = new Layer(BRect(0,0,image_width-1,image_height-1),layer_id,image_view,HS_NORMAL_LAYER,bitmap);
+		new_layer = new Layer(BRect(0,0,image_width-1,image_height-1),
+			layer_id,image_view, HS_NORMAL_LAYER, bitmap, offset);
 	}
 	catch (std::bad_alloc e) {
 		delete bitmap;

--- a/artpaint/paintwindow/Image.h
+++ b/artpaint/paintwindow/Image.h
@@ -109,7 +109,9 @@ void		MultiplyRenderedImagePixels(int32);
 
 bool		SetImageSize();
 
-Layer*		AddLayer(BBitmap*,Layer*,bool add_to_front,float layer_transparency_coefficient=1.0);
+Layer*		AddLayer(BBitmap*,Layer*, bool add_to_front,
+				float layer_transparency_coefficient = 1.0,
+				BRect* offset = NULL);
 bool		ChangeActiveLayer(Layer*,int32);
 bool		ChangeLayerPosition(Layer*,int32,int32);
 bool		ClearCurrentLayer(rgb_color&);


### PR DESCRIPTION
When importing data into a bitmap, it MUST be the same size as the
source bitmap otherwise it doesn't work, which is why pasting a
selection into a layer didn't do anything. There's an alternate form
of ImportBits that allows a data size and offset, so I used that and
passed the offset of the selection through.

Fixes #121