### PR TITLE
Manipulator: kill current manipulator when deleting a layer

### DIFF
--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -392,19 +392,19 @@ void ImageView::MessageReceived(BMessage *message)
 
 		// This comes from layer's view and tells us to delete the layer.
 		case HS_DELETE_LAYER:
-			{
+			if (!PostponeMessageAndFinishManipulator()) {
 				Layer *removed_layer;
 				int32 removed_layer_id;
 				message->FindInt32("layer_id",&removed_layer_id);
 				message->FindPointer("layer_pointer",(void**)&removed_layer);
 				if (the_image->RemoveLayer(removed_layer,removed_layer_id) == TRUE) {
-					ActiveLayerChanged();
+//					ActiveLayerChanged();
 					AddChange();
 				}
 				LayerWindow::ActiveWindowChanged(Window(),the_image->LayerList(),the_image->ReturnThumbnailImage());
 				Invalidate();
-				break;
 			}
+			break;
 
 		// This comes from layer's view and tells us to merge that layer with the one
 		// that is on top of it. If no layer is on top of it nothing should be done.


### PR DESCRIPTION
Use "PostponeMessageAndFinishManipulator" function when deleting a
layer - otherwise you can delete a layer that's being manipulated
and naturally bad things happen.

Fixes #144