### PR TITLE
Don't resize ToolSelectionWindow to default size

### DIFF
--- a/artpaint/tools/ToolSelectionWindow.cpp
+++ b/artpaint/tools/ToolSelectionWindow.cpp
@@ -112,9 +112,6 @@ ToolSelectionWindow::ToolSelectionWindow(BRect frame)
 	//SetWindowAlignment(B_PIXEL_ALIGNMENT, 0, 0, picture_size + kExtraEdge,
 	//	kExtraEdge + 1, 0, 0, picture_size + kExtraEdge, kExtraEdge + 1);
 
-	// remove this if SetWindowAlignment is implemented
-	ResizeBy(0.0, maxDimension - pictureSize);
-
 	fSelectionWindow = this;
 	FloaterManager::AddFloater(this);
 }


### PR DESCRIPTION
The stored window size was ignored and always resized to one
tool icon column.
While true that real horizontal arrangement of the tool icons
still isn't implemented, there's no reason to keep reverting
to one-column tool icons.

Fixes #107