### PR TITLE
Add "ArtPaint" menu

### DIFF
--- a/artpaint/application/FilePanels.cpp
+++ b/artpaint/application/FilePanels.cpp
@@ -38,8 +38,7 @@ ImageSavePanel::ImageSavePanel(const entry_ref& startDir, BMessenger& target,
 	: BFilePanel(B_SAVE_PANEL, &target, &startDir, 0, false, &message)
 {
 	if (Window()->Lock()) {
-		BString title = "ArtPaint: ";
-		title.Append(B_TRANSLATE("Save image"));
+		BString title = B_TRANSLATE("ArtPaint :Save image");
 		Window()->SetTitle(title.String());
 
 		BView* textView = Window()->FindView("text view");

--- a/artpaint/application/PaintApplication.cpp
+++ b/artpaint/application/PaintApplication.cpp
@@ -163,8 +163,7 @@ PaintApplication::MessageReceived(BMessage* message)
 			}
 
 			fImageOpenPanel->SetMessage(&filePanelMessage);
-			fImageOpenPanel->Window()->SetTitle(BString("ArtPaint: ")
-				.Append(B_TRANSLATE("Open image" B_UTF8_ELLIPSIS)).String());
+			fImageOpenPanel->Window()->SetTitle(B_TRANSLATE("ArtPaint: Open image" B_UTF8_ELLIPSIS));
 			fImageOpenPanel->Window()->SetWorkspaces(B_CURRENT_WORKSPACE);
 
 			set_filepanel_strings(fImageOpenPanel);
@@ -188,8 +187,7 @@ PaintApplication::MessageReceived(BMessage* message)
 			}
 
 			fProjectOpenPanel->SetMessage(&filePanelMessage);
-			fProjectOpenPanel->Window()->SetTitle(BString("ArtPaint: ")
-				.Append(B_TRANSLATE("Open project" B_UTF8_ELLIPSIS)).String());
+			fImageOpenPanel->Window()->SetTitle(B_TRANSLATE("ArtPaint: Open project" B_UTF8_ELLIPSIS));
 			fProjectOpenPanel->Window()->SetWorkspaces(B_CURRENT_WORKSPACE);
 
 			set_filepanel_strings(fProjectOpenPanel);
@@ -197,7 +195,7 @@ PaintApplication::MessageReceived(BMessage* message)
 		}	break;
 
 		case HS_SHOW_USER_DOCUMENTATION: {
-			// issued from paint-window's menubar->"Help"->"User Documentation"
+			// issued from paint-window's menubar->"ArtPaint"->"User documentation"
 			BRoster roster;
 			entry_ref mimeHandler;
 			if (roster.FindApp("text/html", &mimeHandler) == B_OK) {

--- a/artpaint/controls/ColorPalette.cpp
+++ b/artpaint/controls/ColorPalette.cpp
@@ -276,9 +276,7 @@ void ColorPaletteWindow::MessageReceived(BMessage *message)
 			open_panel = new BFilePanel(B_OPEN_PANEL, &target, &ref,
 				B_FILE_NODE, true, &message);
 		}
-		char string[256];
-		sprintf(string,"ArtPaint: %s",B_TRANSLATE("Open color set" B_UTF8_ELLIPSIS));
-		open_panel->Window()->SetTitle(string);
+		open_panel->Window()->SetTitle(B_TRANSLATE("ArtPaint: Open color set" B_UTF8_ELLIPSIS));
 		set_filepanel_strings(open_panel);
 		open_panel->Show();
 		break;
@@ -305,8 +303,7 @@ void ColorPaletteWindow::MessageReceived(BMessage *message)
 				&message);
 		}
 		save_panel->SetSaveText(ColorSet::currentSet()->getName());
-		sprintf(string,"ArtPaint: %s",B_TRANSLATE("Save color set"));
-		save_panel->Window()->SetTitle(string);
+		save_panel->Window()->SetTitle(B_TRANSLATE("ArtPaint: Open color set" B_UTF8_ELLIPSIS));
 		set_filepanel_strings(save_panel);
 		save_panel->Show();
 		break;

--- a/artpaint/paintwindow/PaintWindow.cpp
+++ b/artpaint/paintwindow/PaintWindow.cpp
@@ -974,10 +974,57 @@ PaintWindow::openMenuBar()
 {
 	fMenubar = new BMenuBar("menu_bar");
 
-	BMenu* menu = new BMenu(B_TRANSLATE("File"));
+	// the ArtPaint menu
+	BMenu* menu = new BMenu(B_TRANSLATE_SYSTEM_NAME("ArtPaint"));
 	fMenubar->AddItem(menu);
 
+	BMenuItem* item = new PaintWindowMenuItem(B_TRANSLATE("New project"),
+		new BMessage(HS_NEW_PAINT_WINDOW), 'N', 0, this,
+		B_TRANSLATE("Creates a new empty canvas."));
+	item->SetTarget(be_app);
+	menu->AddItem(item);
+
+	item = new PaintWindowMenuItem(B_TRANSLATE("Settings" B_UTF8_ELLIPSIS),
+		new BMessage(HS_SHOW_GLOBAL_SETUP_WINDOW), ',', 0, this,
+		B_TRANSLATE("Opens the settings window."));
+	menu->AddItem(item);
+
+	menu->AddSeparatorItem();
+
+	BMessage* message =  new BMessage(HS_SHOW_USER_DOCUMENTATION);
+	message->AddString("document", "index.html");
+	item = new PaintWindowMenuItem(B_TRANSLATE("User manual" B_UTF8_ELLIPSIS),
+		message, 0, 0, this,
+		B_TRANSLATE("Opens the main documentation for ArtPaint."));
+	item->SetTarget(be_app);
+	menu->AddItem(item);
+
+	message = new BMessage(B_ABOUT_REQUESTED);
+	item = new PaintWindowMenuItem(B_TRANSLATE("About ArtPaint"),
+		message, 0, 0, this,
+		B_TRANSLATE("Opens a window with information about ArtPaint."));
+	item->SetTarget(be_app);
+	menu->AddItem(item);
+
+	menu->AddSeparatorItem();
+
+	message = new BMessage(B_QUIT_REQUESTED);
+	item = new PaintWindowMenuItem(B_TRANSLATE("Close"),
+		message, 'W', 0, this,
+		B_TRANSLATE("Closes the current window."));
+	menu->AddItem(item);
+
+	message = new BMessage(B_QUIT_REQUESTED);
+	item = new PaintWindowMenuItem(B_TRANSLATE("Quit"),
+		message, 'Q', 0, this,
+		B_TRANSLATE("Quits ArtPaint."));
+	item->SetTarget(be_app);
+	menu->AddItem(item);
+
 	// the File menu
+	menu = new BMenu(B_TRANSLATE("File"));
+	fMenubar->AddItem(menu);
+
 	menu_item fileMenu[] = {
 		{ B_TRANSLATE("Open image" B_UTF8_ELLIPSIS), HS_SHOW_IMAGE_OPEN_PANEL,
 			'O', 0, be_app,
@@ -1015,22 +1062,6 @@ PaintWindow::openMenuBar()
 
 	fRecentProjects = new BMenu(B_TRANSLATE("Recent projects"));
 	menu->AddItem(fRecentProjects);
-
-	menu_item fileMenu2[] = {
-		{ "SEPARATOR", 0, 0, 0, NULL, "SEPARATOR" },	// separator
-		{ B_TRANSLATE("Close"), B_QUIT_REQUESTED,
-			'W', 0, this,
-			B_TRANSLATE("Closes the current window.") },
-		{ B_TRANSLATE("Quit"), B_QUIT_REQUESTED,
-			'Q', 0, be_app,
-			B_TRANSLATE("Quits ArtPaint.") }
-	};
-
-	for (uint32 i = 0; i < (sizeof(fileMenu2) / sizeof(menu_item)); ++i) {
-		_AddMenuItems(menu, fileMenu2[i].label, fileMenu2[i].what,
-			fileMenu2[i].shortcut, fileMenu2[i].modifiers, fileMenu2[i].target,
-			fileMenu2[i].help);
-	}
 
 	// the Edit menu
 	menu = new BMenu(B_TRANSLATE("Edit"));
@@ -1229,7 +1260,6 @@ PaintWindow::openMenuBar()
 		new BMessage(HS_CLEAR_CANVAS), 0, 0, this,
 		B_TRANSLATE("Clears all layers.")));
 
-
 	// The Window menu,
 	menu = new BMenu(B_TRANSLATE("Window"));
 	fMenubar->AddItem(menu);
@@ -1309,28 +1339,25 @@ PaintWindow::openMenuBar()
 		new BMessage(HS_RESIZE_WINDOW_TO_FIT), 'Y', 0, this,
 		B_TRANSLATE("Resizes the window to fit image and screen.")));
 	menu->AddSeparatorItem();
-	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Colors"),
+	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Colors" B_UTF8_ELLIPSIS),
 		new BMessage(HS_SHOW_COLOR_WINDOW), 'P', 0, this,
 		B_TRANSLATE("Opens the colors window.")));
-	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Layers"),
+	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Layers" B_UTF8_ELLIPSIS),
 		new BMessage(HS_SHOW_LAYER_WINDOW), 'L', 0, this,
 		B_TRANSLATE("Opens the layers window.")));
-	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Tools"),
+	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Tools" B_UTF8_ELLIPSIS),
 		new BMessage(HS_SHOW_TOOL_WINDOW), 'K', 0, this,
 		B_TRANSLATE("Opens the tool selection window.")));
-	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Tool setup"),
+	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Tool setup" B_UTF8_ELLIPSIS),
 		new BMessage(HS_SHOW_TOOL_SETUP_WINDOW), 'M', 0, this,
 		B_TRANSLATE("Opens the tool setup window.")));
-	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Brushes"),
+	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Brushes" B_UTF8_ELLIPSIS),
 		new BMessage(HS_SHOW_BRUSH_STORE_WINDOW), 'B', 0, this,
 		B_TRANSLATE("Opens the window of stored brushes.")));
-	menu->AddSeparatorItem();
+
 //	menu->AddItem(new PaintWindowMenuItem(_StringForId(NEW_PAINT_WINDOW_STRING),new BMessage(HS_NEW_PAINT_WINDOW),'N',0,this,_StringForId(NEW_PROJECT_HELP_STRING)));
 //	menu->AddSeparatorItem();
 //	menu->AddItem(new BMenuItem(B_TRANSLATE("Window settings" B_UTF8_ELLIPSIS), new BMessage(HS_SHOW_VIEW_SETUP_WINDOW)));
-	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Settings" B_UTF8_ELLIPSIS),
-		new BMessage(HS_SHOW_GLOBAL_SETUP_WINDOW), ',', 0, this,
-		B_TRANSLATE("Opens the settings window.")));
 
 	// This will be only temporary place for add-ons. Later they will be spread
 	// in the menu hierarchy according to their types.
@@ -1339,35 +1366,6 @@ PaintWindow::openMenuBar()
 		"add_on_adder_thread", B_NORMAL_PRIORITY, this);
 	resume_thread(add_on_adder_thread);
 	fMenubar->AddItem(menu);
-
-	// help
-	menu = new BMenu(B_TRANSLATE("Help"));
-	fMenubar->AddItem(menu);
-
-	BMessage* message =  new BMessage(HS_SHOW_USER_DOCUMENTATION);
-	message->AddString("document", "index.html");
-
-	BMenuItem* item = new PaintWindowMenuItem(B_TRANSLATE("User manual" B_UTF8_ELLIPSIS),
-		message, 0, 0, this,
-		B_TRANSLATE("Opens the main documentation for ArtPaint."));
-	item->SetTarget(be_app);
-	menu->AddItem(item);
-
-	message = new BMessage(HS_SHOW_USER_DOCUMENTATION);
-	message->AddString("document", "shortcuts.html");
-	item = new PaintWindowMenuItem(B_TRANSLATE("Shortcuts" B_UTF8_ELLIPSIS),
-		message, 0, 0, this,
-		B_TRANSLATE("Opens a page that describes ArtPaint's keyboard shortcuts."));
-	item->SetTarget(be_app);
-	menu->AddItem(item);
-
-	menu->AddSeparatorItem();
-
-	item = new PaintWindowMenuItem(B_TRANSLATE("About ArtPaint"),
-		message, 0, 0, this,
-		B_TRANSLATE("Opens a window with information about ArtPaint."));
-	menu->AddItem(item);
-	item->SetTarget(be_app);
 
 	_ChangeMenuMode(NO_IMAGE_MENU);
 

--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.artpaint	2034823255
+1	English	application/x-vnd.artpaint	45903161
 Inserts text into the active layer. Same as the text tool.	PaintWindow		Inserts text into the active layer. Same as the text tool.
 Angle:	Manipulators		Angle:
 Cancel	Windows		Cancel
@@ -17,6 +17,7 @@ Click to use eraser.	Tools		Click to use eraser.
 Not enough free memory to finish the effect you requested. You may close other images and try again. Also shortening the depth of undo or disabling undo altogether helps in achieving more memory. If you have other applications running, closing them gives you more free memory. It is also a good idea to save your work at this point, because if the memory runs out completely saving might become impossible. I am very sorry about this inconvenience.	ImageView		Not enough free memory to finish the effect you requested. You may close other images and try again. Also shortening the depth of undo or disabling undo altogether helps in achieving more memory. If you have other applications running, closing them gives you more free memory. It is also a good idea to save your work at this point, because if the memory runs out completely saving might become impossible. I am very sorry about this inconvenience.
 Click to draw a freehand line.	Tools		Click to draw a freehand line.
 Cursor	Windows		Cursor
+ArtPaint: Open color set…	ColorPalette		ArtPaint: Open color set…
 Crop…	PaintWindow		Crop…
 Click to make a selection.	Tools		Click to make a selection.
 Bummer	UndoQueue		Bummer
@@ -26,6 +27,7 @@ Merge with front layer	Image		Merge with front layer
 Alpha	Tools		Alpha
 Width:	Tools		Width:
 Creates a new empty canvas.	PaintWindow		Creates a new empty canvas.
+ArtPaint	System name		ArtPaint
 Click to blur the image.	Tools		Click to blur the image.
 Rotate all layers.	PaintWindow		Rotate all layers.
 Rectangle tool	Tools		Rectangle tool
@@ -33,7 +35,6 @@ Not enough free memory to start the effect you requested. You may close other im
 Click to draw a straight line.	Tools		Click to draw a straight line.
 Clear selection	PaintWindow		Clear selection
 Add layer	PaintWindow		Add layer
-Colors	PaintWindow		Colors
 Selector tool	Tools		Selector tool
 Not a color set file	ColorPalette		Not a color set file
 Click to select a painting color.	ColorPalette		Click to select a painting color.
@@ -56,12 +57,10 @@ Erasing the image.	Tools		Erasing the image.
 File	PaintWindow		File
 Opens the window of stored brushes.	PaintWindow		Opens the window of stored brushes.
 Right:	Manipulators		Right:
-Tools	PaintWindow		Tools
 Saves the project under its current name.	PaintWindow		Saves the project under its current name.
 Redo not available	UndoQueue		Redo not available
 Drawing a freehand line.	Tools		Drawing a freehand line.
 Random	Tools		Random
-Tool setup	PaintWindow		Tool setup
 Flip horizontally	Manipulators		Flip horizontally
 Opens the tool setup window.	PaintWindow		Opens the tool setup window.
 Flow:	Tools		Flow:
@@ -137,6 +136,7 @@ Redo not available	PaintWindow		Redo not available
 Opens the settings window.	PaintWindow		Opens the settings window.
 Unlimited	Windows		Unlimited
 Opaque	Manipulators		Opaque
+Layers…	PaintWindow		Layers…
 Windows	Windows		Windows
 Making a fill.	Tools		Making a fill.
 Speed:	Tools		Speed:
@@ -152,7 +152,6 @@ Store brush	Tools		Store brush
 Painting with a hairy brush.	Tools		Painting with a hairy brush.
 Edit	PaintWindow		Edit
 Drawing an ellipse.	Tools		Drawing an ellipse.
-Save image	FilePanels		Save image
 Shrink selection	ImageView		Shrink selection
 Freehand line	Tools		Freehand line
 Fill tool	Tools		Fill tool
@@ -161,7 +160,6 @@ Enable antialiasing	Tools		Enable antialiasing
 Turns the grid off.	PaintWindow		Turns the grid off.
 Undo	Windows		Undo
 Not enough free memory to create the image. Please try again with a smaller image size.	PaintWindow		Not enough free memory to create the image. Please try again with a smaller image size.
-Open project…	PaintApplication		Open project…
 Airbrush	Tools		Airbrush
 Height:	Manipulators		Height:
 Sets the grid to 2 by 2 pixels.	PaintWindow		Sets the grid to 2 by 2 pixels.
@@ -173,6 +171,7 @@ Clear canvas	PaintWindow		Clear canvas
 OK	ColorPalette		OK
 Merge with back layer	LayerView		Merge with back layer
 Using the airbrush.	Tools		Using the airbrush.
+Tool setup…	PaintWindow		Tool setup…
 Magic wand	Tools		Magic wand
 Adjusting the layer's transparency.	Tools		Adjusting the layer's transparency.
 Little	Tools		Little
@@ -180,6 +179,7 @@ Flips all layers horizontally.	PaintWindow		Flips all layers horizontally.
 Click to paint with a brush.	Tools		Click to paint with a brush.
 Tool setup	Windows		Tool setup
 Free 2D transform	FreeTransformManipulator		Free 2D transform
+Colors…	PaintWindow		Colors…
 Copy	PaintWindow		Copy
 Enable preview	Tools		Enable preview
 Undos the previous action.	PaintWindow		Undos the previous action.
@@ -188,14 +188,13 @@ Standard sizes	PaintWindow		Standard sizes
 Datatype setup: %name%	Windows		Datatype setup: %name%
 Options	Tools		Options
 Clear canvas	Image		Clear canvas
+New project	PaintWindow		New project
 All layers	PaintWindow		All layers
 Sets the zoom level to 800%.	PaintWindow		Sets the zoom level to 800%.
 No data translator	Windows		No data translator
 Drag the text to correct position and set its appearance.	Tools		Drag the text to correct position and set its appearance.
 Layer %ld / %ld	ImageView		Layer %ld / %ld
 Select the canvas size you want.	PaintWindow		Select the canvas size you want.
-Brushes	PaintWindow		Brushes
-Open image…	PaintApplication		Open image…
 Active layer	PaintWindow		Active layer
 Rotate the active layer.	PaintWindow		Rotate the active layer.
 Zooms into the image.	PaintWindow		Zooms into the image.
@@ -220,7 +219,6 @@ Color	Tools		Color
 Drag the text to correct position and set its appearance.	Manipulators		Drag the text to correct position and set its appearance.
 Save image as…	PaintWindow		Save image as…
 Brushes	Windows		Brushes
-Shortcuts…	PaintWindow		Shortcuts…
 Translate…	Manipulators		Translate…
 Cannot write to file	ColorPalette		Cannot write to file
 Delete current set	ColorPalette		Delete current set
@@ -236,8 +234,10 @@ Sets the grid to 8 by 8 pixels.	PaintWindow		Sets the grid to 8 by 8 pixels.
 Copies the selection of all layers to the clipboard.	PaintWindow		Copies the selection of all layers to the clipboard.
 Transparent	Tools		Transparent
 Click here to open color panel.	StatusView		Click here to open color panel.
+ArtPaint: Open image…	PaintApplication		ArtPaint: Open image…
 Error reading file	ColorPalette		Error reading file
 Recent projects	PaintWindow		Recent projects
+Brushes…	PaintWindow		Brushes…
 Click on the image to rotate, move or stretch it.	FreeTransformManipulator		Click on the image to rotate, move or stretch it.
 Color variance:	Tools		Color variance:
 Clear layer	PaintWindow		Clear layer
@@ -252,7 +252,6 @@ Click to paint with airbrush.	Tools		Click to paint with airbrush.
 Colors	Windows		Colors
 Move the active layer.	PaintWindow		Move the active layer.
 Off	PaintWindow		Off
-Opens a page that describes ArtPaint's keyboard shortcuts.	PaintWindow		Opens a page that describes ArtPaint's keyboard shortcuts.
 Cuts the selection to the clipboard.	PaintWindow		Cuts the selection to the clipboard.
 Rotation:	Manipulators		Rotation:
 Ellipse tool	Tools		Ellipse tool
@@ -270,13 +269,14 @@ Tools	Windows		Tools
 Visible	LayerView		Visible
 Grow selection	ImageView		Grow selection
 Use the tool by pressing the mouse-button.	Tools		Use the tool by pressing the mouse-button.
-Colors	ColorPalette		Colors
 Opens a window with information about ArtPaint.	PaintWindow		Opens a window with information about ArtPaint.
+Colors	ColorPalette		Colors
 Save	ImageView		Save
 Layer	PaintWindow		Layer
 Empty paint window	PaintWindow		Empty paint window
 No options	Windows		No options
 Flip vertically	Manipulators		Flip vertically
+ArtPaint: Open project…	PaintApplication		ArtPaint: Open project…
 Tool cursor	Windows		Tool cursor
 The undo-mechanism has run out of memory.\nThe depth of undo will be limited so that the most recent events can be kept in memory. It is advisable to save your work at this point to avoid any loss of data in case the memory runs out completely.\nYou may also want to adjust the undo-depth in the settings-window.	UndoQueue		The undo-mechanism has run out of memory.\nThe depth of undo will be limited so that the most recent events can be kept in memory. It is advisable to save your work at this point to avoid any loss of data in case the memory runs out completely.\nYou may also want to adjust the undo-depth in the settings-window.
 Intelligent scissors	Tools		Intelligent scissors
@@ -321,7 +321,6 @@ No configuration options available.	Tools		No configuration options available.
 Open color set…	ColorPalette		Open color set…
 Wand tolerance	Tools		Wand tolerance
 Invert selection	ImageView		Invert selection
-Help	PaintWindow		Help
 Much	Tools		Much
 Not implemented yet.	Tools		Not implemented yet.
 Change the transparency with the slider.	Manipulators		Change the transparency with the slider.
@@ -329,9 +328,9 @@ Top:	Manipulators		Top:
 Resizes the window to fit image and screen.	PaintWindow		Resizes the window to fit image and screen.
 Unsaved changes!	ImageView		Unsaved changes!
 Un-selects all	PaintWindow		Un-selects all
+ArtPaint :Save image	FilePanels		ArtPaint :Save image
 Layers	LayerWindow		Layers
 Flips the active layer vertically.	PaintWindow		Flips the active layer vertically.
-Layers	PaintWindow		Layers
 Width:	Manipulators		Width:
 Sets the zoom level to 200%.	PaintWindow		Sets the zoom level to 200%.
 Undo not available	UndoQueue		Undo not available
@@ -343,6 +342,7 @@ Tolerance:	Tools		Tolerance:
 Using the tool.	Tools		Using the tool.
 Drag the image to correct position.	Manipulators		Drag the image to correct position.
 Lock	Manipulators	Keep the aspect ratio	Lock
+Tools…	PaintWindow		Tools…
 Add area	Tools		Add area
 Eraser	Tools		Eraser
 Recent images	PaintWindow		Recent images


### PR DESCRIPTION
* Move "User documentation", About, Close, Quit to new "ArtPaint" menu.
* Remove "Help" menu.
* Move "Settings" from "Window" menu.
* Add "New project" to new "ArtPaint" menu.
  Leave "New project" also in "File" menu, as people may look there too,
  because that's where you open project files after all, although a new
  project (= new canvas) doesn't of itself need to create a project file.
* Add ellipsis to 'special windows' (Colors, Tools...) in "Window" menu.
* Make "ArtPaint" localizable.
* Update catkeys.