### PR TITLE
Brush/Freehand tool: fix single-click drawing

### DIFF
--- a/artpaint/tools/BrushTool.cpp
+++ b/artpaint/tools/BrushTool.cpp
@@ -124,6 +124,10 @@ BrushTool::UseTool(ImageView *view, uint32 buttons, BPoint point, BPoint viewPoi
 		point.y - brush_height_per_2, point.x + brush_width_per_2,
 		point.y + brush_height_per_2);
 	SetLastUpdatedRect(updated_rect);
+	buffer->Lock();
+	BitmapUtilities::CompositeBitmapOnSource(buffer, srcBuffer,
+		tmpBuffer, updated_rect);
+	buffer->Unlock();
 	prev_point = point;
 
 	ImageUpdater* imageUpdater = new ImageUpdater(view, 20000);

--- a/artpaint/tools/FreeLineTool.cpp
+++ b/artpaint/tools/FreeLineTool.cpp
@@ -125,6 +125,8 @@ FreeLineTool::UseTool(ImageView* view, uint32 buttons, BPoint point, BPoint)
 	// We have to use Draw, because Invalidate causes flickering by erasing
 	// the area before calling Draw.
 	view->Draw(view->convertBitmapRectToView(updated_rect));
+	view->UpdateImage(updated_rect);
+	view->Sync();
 	view->Window()->Unlock();
 
 	SetLastUpdatedRect(updated_rect);


### PR DESCRIPTION
Single-click to draw a dot with the brush and freehand tool now
makes sure the compositing of the stroke happens even if no stroke
is drawn.

Fixes #184