### PR TITLE
Crash fix: fix fImageOpenPanel that shoulda been fProjectOpenPanel

### DIFF
--- a/artpaint/application/PaintApplication.cpp
+++ b/artpaint/application/PaintApplication.cpp
@@ -186,7 +186,7 @@ PaintApplication::MessageReceived(BMessage* message)
 			}
 
 			fProjectOpenPanel->SetMessage(&filePanelMessage);
-			fImageOpenPanel->Window()->SetTitle(B_TRANSLATE("ArtPaint: Open project" B_UTF8_ELLIPSIS));
+			fProjectOpenPanel->Window()->SetTitle(B_TRANSLATE("ArtPaint: Open project" B_UTF8_ELLIPSIS));
 			fProjectOpenPanel->Window()->SetWorkspaces(B_CURRENT_WORKSPACE);
 
 			set_filepanel_strings(fProjectOpenPanel);


### PR DESCRIPTION
Looks like a copy/paste mistake from the localization; trying to set a label on the wrong dialog box that was NULL. 

Fixes #191