### PR TITLE
Alpha checker bg: Added checkerboard alpha background as seen in similar tools

### DIFF
--- a/artpaint/Utilities/BitmapUtilities.cpp
+++ b/artpaint/Utilities/BitmapUtilities.cpp
@@ -166,3 +166,44 @@ BitmapUtilities::ClearBitmap(BBitmap* bitmap, uint32 color, BRect* area)
 		bits += bpr - width;
 	}
 }
+
+
+void
+BitmapUtilities::CheckerBitmap(BBitmap* bitmap,
+	uint32 color1, uint32 color2, uint32 grid_size,
+	BRect* area)
+{
+	uint32 width = bitmap->Bounds().IntegerWidth()+1;
+	uint32 height = bitmap->Bounds().IntegerHeight()+1;
+	uint32 bpr = bitmap->BytesPerRow() / 4;
+
+	int32 start_x = 0;
+	int32 start_y = 0;
+
+	if (area) {
+		width = area->IntegerWidth()+1;
+		height = area->IntegerHeight()+1;
+		start_x = (int32)area->left;
+		start_y = (int32)area->top;
+	}
+
+	uint32 grid_color[2] = { color1, color2 };
+	uint32 cur_color = grid_color[0];
+
+	uint32* bits = (uint32*)bitmap->Bits();
+	bits += start_x + bpr * start_y;
+
+	for (int y = 0;y < height;++y) {
+		for (int x = 0;x < width;++x) {
+			int row = (x+start_x) / grid_size;
+			int col = (y+start_y) / grid_size;
+			if (row % 2 == col % 2)
+				cur_color = grid_color[1];
+			else
+				cur_color = grid_color[0];
+
+			*bits++ = cur_color;
+		}
+		bits += bpr - width;
+	}
+}

--- a/artpaint/Utilities/BitmapUtilities.cpp
+++ b/artpaint/Utilities/BitmapUtilities.cpp
@@ -4,6 +4,7 @@
  *
  * Authors:
  * 		Heikki Suhonen <heikki.suhonen@gmail.com>
+ *		Dale Cieslak <dcieslak@yahoo.com>
  *
  */
 #include "BitmapUtilities.h"
@@ -181,8 +182,13 @@ BitmapUtilities::CheckerBitmap(BBitmap* bitmap,
 	int32 start_y = 0;
 
 	if (area) {
+		*area = *area & bitmap->Bounds();
 		width = area->IntegerWidth()+1;
 		height = area->IntegerHeight()+1;
+		if (width > bitmap->Bounds().IntegerWidth()+1)
+			return;
+		if (height > bitmap->Bounds().IntegerHeight()+1)
+			return;
 		start_x = (int32)area->left;
 		start_y = (int32)area->top;
 	}
@@ -192,18 +198,19 @@ BitmapUtilities::CheckerBitmap(BBitmap* bitmap,
 
 	uint32* bits = (uint32*)bitmap->Bits();
 	bits += start_x + bpr * start_y;
+	uint32 row_size = bpr - width;
 
-	for (int y = 0;y < height;++y) {
-		for (int x = 0;x < width;++x) {
-			int row = (x+start_x) / grid_size;
-			int col = (y+start_y) / grid_size;
-			if (row % 2 == col % 2)
+	for (int y = start_y;y < height+start_y;++y) {
+		int rowMod2 = (y / grid_size) % 2;
+		for (int x = start_x;x < width+start_x;++x) {
+			int col = x / grid_size;
+			if (rowMod2 == col % 2)
 				cur_color = grid_color[1];
 			else
 				cur_color = grid_color[0];
 
 			*bits++ = cur_color;
 		}
-		bits += bpr - width;
+		bits += row_size;
 	}
 }

--- a/artpaint/Utilities/BitmapUtilities.h
+++ b/artpaint/Utilities/BitmapUtilities.h
@@ -24,6 +24,9 @@ public:
 							BRect updated_rect);
 	static  void		ClearBitmap(BBitmap* bitmap, uint32 color,
 							BRect* area = NULL);
+	static	void		CheckerBitmap(BBitmap* bitmap,
+							uint32 color1, uint32 color2,
+							uint32 grid_size, BRect* area = NULL);
 };
 
 

--- a/artpaint/application/SettingsServer.cpp
+++ b/artpaint/application/SettingsServer.cpp
@@ -234,7 +234,7 @@ status_t
 SettingsServer::SetValue(Setting type, const BString& field, bool value)
 {
 	if (BMessage* settings = _SettingsForType(type)) {
-		if (settings->RemoveName(field.String()) == B_OK)
+		if (settings->RemoveName(field.String()) != B_ERROR)
 			return settings->AddBool(field.String(), value);
 	}
 	return B_ERROR;
@@ -245,8 +245,19 @@ status_t
 SettingsServer::SetValue(Setting type, const BString& field, int32 value)
 {
 	if (BMessage* settings = _SettingsForType(type)) {
-		if (settings->RemoveName(field.String()) == B_OK)
+		if (settings->RemoveName(field.String()) != B_ERROR)
 			return settings->AddInt32(field.String(), value);
+	}
+	return B_ERROR;
+}
+
+
+status_t
+SettingsServer::SetValue(Setting type, const BString& field, uint32 value)
+{
+	if (BMessage* settings = _SettingsForType(type)) {
+		if (settings->RemoveName(field.String()) != B_ERROR)
+			return settings->AddUInt32(field.String(), value);
 	}
 	return B_ERROR;
 }
@@ -256,7 +267,7 @@ status_t
 SettingsServer::SetValue(Setting type, const BString& field, const BRect& value)
 {
 	if (BMessage* settings = _SettingsForType(type)) {
-		if (settings->RemoveName(field.String()) == B_OK)
+		if (settings->RemoveName(field.String()) != B_ERROR)
 			return settings->AddRect(field.String(), value);
 	}
 	return B_ERROR;
@@ -267,7 +278,7 @@ status_t
 SettingsServer::SetValue(Setting type, const BString& field, const BPoint& value)
 {
 	if (BMessage* settings = _SettingsForType(type)) {
-		if (settings->RemoveName(field.String()) == B_OK)
+		if (settings->RemoveName(field.String()) != B_ERROR)
 			return settings->AddPoint(field.String(), value);
 	}
 	return B_ERROR;
@@ -278,7 +289,7 @@ status_t
 SettingsServer::SetValue(Setting type, const BString& field, const char* value)
 {
 	if (BMessage* settings = _SettingsForType(type)) {
-		if (settings->RemoveName(field.String()) == B_OK)
+		if (settings->RemoveName(field.String()) != B_ERROR)
 			return settings->AddString(field.String(), value);
 	}
 	return B_ERROR;
@@ -289,7 +300,7 @@ status_t
 SettingsServer::SetValue(Setting type, const BString& field, const BString& value)
 {
 	if (BMessage* settings = _SettingsForType(type)) {
-		if (settings->RemoveName(field.String()) == B_OK)
+		if (settings->RemoveName(field.String()) != B_ERROR)
 			return settings->AddString(field.String(), value);
 	}
 	return B_ERROR;
@@ -301,7 +312,7 @@ SettingsServer::SetValue(Setting type, const BString& field, type_code typeCode,
 	const void* value, ssize_t size)
 {
 	if (BMessage* settings = _SettingsForType(type)) {
-		if (settings->RemoveName(field.String()) == B_OK) {
+		if (settings->RemoveName(field.String()) != B_ERROR) {
 			return settings->AddData(field.String(), typeCode, value,
 				size);
 		}

--- a/artpaint/application/SettingsServer.h
+++ b/artpaint/application/SettingsServer.h
@@ -72,6 +72,10 @@ static const char skPosition[]					= "position";
 static const char skMimeType[]					= "mime_type";
 static const char skViews[]						= "views";
 
+static const char skBgGridSize[]				= "bg_grid_size";
+static const char skBgColor1[]					= "bg_color1";
+static const char skBgColor2[]					= "bg_color2";
+
 
 class SettingsServer
 {
@@ -100,6 +104,8 @@ public:
 										bool value);
 			status_t				SetValue(Setting type, const BString& field,
 										int32 value);
+			status_t				SetValue(Setting type, const BString& field,
+										uint32 value);
 			status_t				SetValue(Setting type, const BString& field,
 										const BRect& value);
 			status_t				SetValue(Setting type, const BString& field,

--- a/artpaint/layers/Layer.cpp
+++ b/artpaint/layers/Layer.cpp
@@ -185,6 +185,7 @@ int32 Layer::calc_mini_image()
 	rgb_color rgb1, rgb2;
 	rgb1.red = rgb1.green = rgb1.blue = 0xBB;
 	rgb2.red = rgb2.green = rgb2.blue = 0x99;
+	rgb1.alpha = rgb2.alpha = 0xFF;
 	color1 = RGBColorToBGRA(rgb1);
 	color2 = RGBColorToBGRA(rgb2);
 

--- a/artpaint/paintwindow/Image.cpp
+++ b/artpaint/paintwindow/Image.cpp
@@ -1453,20 +1453,20 @@ int32 Image::DoRenderPreview(BRect area,int32 resolution)
 		uint32 color1;
 		uint32 color2;
 
+		gridSize = 20;
+		rgb_color rgb1, rgb2;
+		rgb1.red = rgb1.green = rgb1.blue = 0xBB;
+		rgb2.red = rgb2.green = rgb2.blue = 0x99;
+		color1 = RGBColorToBGRA(rgb1);
+		color2 = RGBColorToBGRA(rgb2);
+
 		if (SettingsServer* server = SettingsServer::Instance()) {
 			BMessage settings;
 			server->GetApplicationSettings(&settings);
 
-			settings.FindInt32(skBgGridSize, (int32*)&gridSize);
-			settings.FindUInt32(skBgColor1, (uint32*)&color1);
-			settings.FindUInt32(skBgColor2, (uint32*)&color2);
-		} else {
-			gridSize = 20;
-			rgb_color rgb1, rgb2;
-			rgb1.red = rgb1.green = rgb1.blue = 0xBB;
-			rgb2.red = rgb2.green = rgb2.blue = 0x99;
-			color1 = RGBColorToBGRA(rgb1);
-			color2 = RGBColorToBGRA(rgb2);
+			gridSize = settings.GetInt32(skBgGridSize, gridSize);
+			color1 = settings.GetUInt32(skBgColor1, color1);
+			color2 = settings.GetUInt32(skBgColor2, color2);
 		}
 
 		BitmapUtilities::CheckerBitmap(rendered_image,

--- a/artpaint/paintwindow/Image.h
+++ b/artpaint/paintwindow/Image.h
@@ -90,7 +90,8 @@ static	int32		candidate_creator(void*);
 
 
 static	int32		enter_render(void*);
-		int32		DoRender(BRect);
+static  int32  		enter_render_nobg(void*);
+		int32		DoRender(BRect, bool bg = true);
 
 
 static	int32		enter_render_preview(void*);
@@ -101,8 +102,8 @@ public:
 			Image(ImageView*,float,float,UndoQueue*);
 			~Image();
 
-void		Render();
-void		Render(BRect);
+void		Render(bool bg = true);
+void		Render(BRect, bool bg = true);
 void		RenderPreview(BRect,int32);
 void		RenderPreview(BRegion&,int32);
 void		MultiplyRenderedImagePixels(int32);

--- a/artpaint/paintwindow/PaintWindow.h
+++ b/artpaint/paintwindow/PaintWindow.h
@@ -93,6 +93,7 @@ public:
 			// this is the function used by layer-window to inform paint-windows
 			// that it has been closed if no target window is specified ATM.
 	//static	void			LayerWindowClosed();
+	static  void				Redraw();
 
 			// This returns the number of paint-windows
 	static	int32				CountPaintWindows() { return sgPaintWindowCount; }

--- a/artpaint/windows/GlobalSetupWindow.cpp
+++ b/artpaint/windows/GlobalSetupWindow.cpp
@@ -539,26 +539,24 @@ GlobalSetupWindow::BackgroundControlView::BackgroundControlView()
 	SetLayout(new BGroupLayout(B_VERTICAL));
 
 	BMessage* message = new BMessage(kBgGridSizeChanged);
-	fGridSizeControl = new NumberSliderControl(B_TRANSLATE("Grid Size"),
+	fGridSizeControl = new NumberSliderControl(B_TRANSLATE("Grid size:"),
 								"0", message, 4, 50, false, true);
 
-	BRect frame(0, 0, 200, 100);
+	BRect frame(0, 0, 250, 100);
 
 	fBgContainer = new PreviewPane(frame);
 
 	BRect frameSwatch = (0, 0, 30, 30);
 
 	fColorSwatch1 = new ColorSwatch(frameSwatch, "color1");
-	fColorSwatch1->SetToolTip(B_TRANSLATE("Drag color from palette to set"));
+	fColorSwatch1->SetToolTip(B_TRANSLATE("Drop a color from the Colors window"));
 	fColorSwatch2 = new ColorSwatch(frameSwatch, "color2");
-	fColorSwatch2->SetToolTip(B_TRANSLATE("Drag color from palette to set"));
+	fColorSwatch2->SetToolTip(B_TRANSLATE("Drop a color from the Colors window"));
 
-	BStringView* labelColor1 = new BStringView("color1label",
-		B_TRANSLATE("Color 1"));
-	BStringView* labelColor2 = new BStringView("color2label",
-		B_TRANSLATE("Color 2"));
+	BStringView* labelColors = new BStringView("color1label",
+		B_TRANSLATE("Colors:"));
 
-	fDefaultsButton = new BButton(B_TRANSLATE("Revert"),
+	fDefaultsButton = new BButton(B_TRANSLATE("Defaults"),
 		new BMessage(kBgRevertToDefaults));
 
 	BGridLayout* gridLayout = BGridLayoutBuilder(5.0, 5.0)
@@ -566,22 +564,22 @@ GlobalSetupWindow::BackgroundControlView::BackgroundControlView()
 		.Add(fGridSizeControl->LabelLayoutItem(), 0, 0)
 		.Add(fGridSizeControl->TextViewLayoutItem(), 1, 0)
 		.Add(fGridSizeControl->Slider(), 2, 0);
-	gridLayout->SetMinColumnWidth(2, StringWidth("SLIDERSLIDERSLIDER"));
+	gridLayout->SetMinColumnWidth(2, StringWidth("SLIDERSLIDERSLIDERSLIDER"));
 
 	AddChild(BGroupLayoutBuilder(B_VERTICAL, 5.0)
 		.Add(fBgContainer)
 		.AddGroup(B_HORIZONTAL, 5.0)
-			.Add(labelColor1)
+			.Add(labelColors)
 			.Add(fColorSwatch1)
-		.End()
-		.AddGroup(B_HORIZONTAL, 5.0)
-			.Add(labelColor2)
 			.Add(fColorSwatch2)
 		.End()
 		.Add(gridLayout->View())
 		.AddGlue()
-		.Add(fDefaultsButton)
-		.SetInsets(20.0, 20.0, 10.0, 10.0)
+		.AddGroup(B_HORIZONTAL, 5.0)
+			.Add(fDefaultsButton)
+			.AddGlue()
+		.End()
+		.SetInsets(20.0, 25.0, 10.0, 10.0)
 	);
 
 	_SetDefaults();
@@ -803,6 +801,15 @@ ColorSwatch::SetColor(uint32 color)
 }
 
 
+void
+ColorSwatch::MouseDown(BPoint point)
+{
+	rgb_color color = BGRAColorToRGB(fColor);
+	ColorPaletteWindow::showPaletteWindow();
+	ColorPaletteWindow::ChangePaletteColor(color);
+}
+
+
 // #pragma mark -- GlobalSetupWindow
 
 
@@ -828,14 +835,14 @@ GlobalSetupWindow::GlobalSetupWindow(const BPoint& leftTop)
 	tab->SetLabel(B_TRANSLATE("Undo"));
 
 	tab = new BTab();
+	fBackgroundControlView = new BackgroundControlView;
+	fTabView->AddTab(fBackgroundControlView, tab);
+	tab->SetLabel(B_TRANSLATE("Transparency"));
+
+	tab = new BTab();
 	fGeneralControlView = new GeneralControlView;
 	fTabView->AddTab(fGeneralControlView, tab);
 	tab->SetLabel(B_TRANSLATE("Miscellaneous"));
-
-	tab = new BTab();
-	fBackgroundControlView = new BackgroundControlView;
-	fTabView->AddTab(fBackgroundControlView, tab);
-	tab->SetLabel(B_TRANSLATE("Background"));
 
 	layout->AddView(fTabView);
 	layout->AddView(BGroupLayoutBuilder(B_HORIZONTAL, 10.0)
@@ -844,6 +851,7 @@ GlobalSetupWindow::GlobalSetupWindow(const BPoint& leftTop)
 			new BMessage(kCloseAndDiscardSettings)))
 		.Add(new BButton(B_TRANSLATE("OK"),
 			new BMessage(kCloseAndApplySettings)))
+		.AddGlue()
 		.TopView()
 	);
 	layout->SetInsets(10.0, 10.0, 10.0, 10.0);
@@ -903,7 +911,7 @@ GlobalSetupWindow::MessageReceived(BMessage* message)
 void
 GlobalSetupWindow::ShowGlobalSetupWindow()
 {
-	BRect frame(100, 100, 350, 300);
+	BRect frame(100, 100, 300, 300);
 	if (SettingsServer* server = SettingsServer::Instance()) {
 		BMessage settings;
 		server->GetApplicationSettings(&settings);

--- a/artpaint/windows/GlobalSetupWindow.cpp
+++ b/artpaint/windows/GlobalSetupWindow.cpp
@@ -12,12 +12,15 @@
 
 #include "GlobalSetupWindow.h"
 
+#include "BitmapUtilities.h"
 #include "BrushStoreWindow.h"
 #include "Cursors.h"
 #include "ColorPalette.h"
 #include "LayerWindow.h"
 #include "ManipulatorWindow.h"
 #include "NumberControl.h"
+#include "NumberSliderControl.h"
+#include "PaintWindow.h"
 #include "SettingsServer.h"
 #include "ToolSelectionWindow.h"
 #include "ToolSetupWindow.h"
@@ -28,6 +31,7 @@
 #include <Button.h>
 #include <Catalog.h>
 #include <CheckBox.h>
+#include <Control.h>
 #include <GroupLayout.h>
 #include <GridLayoutBuilder.h>
 #include <GroupLayoutBuilder.h>
@@ -37,11 +41,15 @@
 #include <TabView.h>
 
 
+#include <stdio.h>
+
+
 #undef B_TRANSLATION_CONTEXT
 #define B_TRANSLATION_CONTEXT "Windows"
 
 
 using ArtPaint::Interface::NumberControl;
+using ArtPaint::Interface::NumberSliderControl;
 
 
 const uint32 kCloseAndApplySettings				= 'caas';
@@ -62,6 +70,13 @@ const uint32 kUndoDepthAdjusted					= '_uda';
 const uint32 kToolCursorMode					= '_too';
 const uint32 kCrossHairCursorMode				= '_cro';
 const uint32 kConfirmShutdownChanged			= '_con';
+
+const uint32 kBgColorsChanged					= '_bgc';
+const uint32 kBgGridSizeChanged					= '_bgg';
+const uint32 kBgRevertToDefaults     			= '_bgd';
+
+const uint32 kDrop								= '_drp';
+
 
 GlobalSetupWindow* GlobalSetupWindow::fSetupWindow = NULL;
 
@@ -486,6 +501,308 @@ GlobalSetupWindow::GeneralControlView::ApplyChanges()
 }
 
 
+// #pragma mark -- BackgroundControlView
+
+
+class GlobalSetupWindow::BackgroundControlView : public BView {
+public:
+						BackgroundControlView();
+	virtual				~BackgroundControlView() {}
+
+	virtual	void		AllAttached();
+	virtual	void		MessageReceived(BMessage* message);
+
+			void		ApplyChanges();
+			void		SetColor(PreviewPane* which, uint32 color);
+
+private:
+			void		_SetDefaults();
+			void		_Update();
+
+private:
+			NumberSliderControl*	fGridSizeControl;
+			BBitmap*				fPreview;
+			PreviewPane*			fBgContainer;
+			ColorSwatch*			fColorSwatch1;
+			ColorSwatch*			fColorSwatch2;
+			BButton*				fDefaultsButton;
+
+			uint32		fColor1;
+			uint32		fColor2;
+			int32		fGridSize;
+};
+
+
+GlobalSetupWindow::BackgroundControlView::BackgroundControlView()
+	: BView("background control view", 0)
+{
+	SetLayout(new BGroupLayout(B_VERTICAL));
+
+	BMessage* message = new BMessage(kBgGridSizeChanged);
+	fGridSizeControl = new NumberSliderControl(B_TRANSLATE("Grid Size"),
+								"0", message, 4, 50, false, true);
+
+	BRect frame(0, 0, 200, 100);
+
+	fBgContainer = new PreviewPane(frame);
+
+	BRect frameSwatch = (0, 0, 30, 30);
+
+	fColorSwatch1 = new ColorSwatch(frameSwatch, "color1");
+	fColorSwatch1->SetToolTip(B_TRANSLATE("Drag color from palette to set"));
+	fColorSwatch2 = new ColorSwatch(frameSwatch, "color2");
+	fColorSwatch2->SetToolTip(B_TRANSLATE("Drag color from palette to set"));
+
+	BStringView* labelColor1 = new BStringView("color1label",
+		B_TRANSLATE("Color 1"));
+	BStringView* labelColor2 = new BStringView("color2label",
+		B_TRANSLATE("Color 2"));
+
+	fDefaultsButton = new BButton(B_TRANSLATE("Revert"),
+		new BMessage(kBgRevertToDefaults));
+
+	BGridLayout* gridLayout = BGridLayoutBuilder(5.0, 5.0)
+		.Add(fGridSizeControl, 0, 0, 0, 0)
+		.Add(fGridSizeControl->LabelLayoutItem(), 0, 0)
+		.Add(fGridSizeControl->TextViewLayoutItem(), 1, 0)
+		.Add(fGridSizeControl->Slider(), 2, 0);
+	gridLayout->SetMinColumnWidth(2, StringWidth("SLIDERSLIDERSLIDER"));
+
+	AddChild(BGroupLayoutBuilder(B_VERTICAL, 5.0)
+		.Add(fBgContainer)
+		.AddGroup(B_HORIZONTAL, 5.0)
+			.Add(labelColor1)
+			.Add(fColorSwatch1)
+		.End()
+		.AddGroup(B_HORIZONTAL, 5.0)
+			.Add(labelColor2)
+			.Add(fColorSwatch2)
+		.End()
+		.Add(gridLayout->View())
+		.AddGlue()
+		.Add(fDefaultsButton)
+		.SetInsets(20.0, 20.0, 10.0, 10.0)
+	);
+
+	_SetDefaults();
+
+	if (SettingsServer* server = SettingsServer::Instance()) {
+		 BMessage settings;
+		 server->GetApplicationSettings(&settings);
+
+		fGridSize = settings.GetInt32(skBgGridSize, fGridSize);
+		fColor1 = settings.GetUInt32(skBgColor1, fColor1);
+		fColor2 = settings.GetUInt32(skBgColor2, fColor2);
+	}
+
+	fGridSize = max_c(4, fGridSize);
+}
+
+
+void
+GlobalSetupWindow::BackgroundControlView::AllAttached()
+{
+	if (Parent())
+		SetViewColor(Parent()->ViewColor());
+
+	fGridSizeControl->SetValue(fGridSize);
+
+	fColorSwatch1->SetColor(fColor1);
+	fColorSwatch2->SetColor(fColor2);
+
+	fGridSizeControl->SetTarget(this);
+	fColorSwatch1->SetTarget(this);
+	fColorSwatch2->SetTarget(this);
+	fDefaultsButton->SetTarget(this);
+
+	_Update();
+}
+
+
+void
+GlobalSetupWindow::BackgroundControlView::MessageReceived(BMessage* message)
+{
+	switch (message->what) {
+		case kBgGridSizeChanged: {
+			fGridSize = fGridSizeControl->Value();
+			_Update();
+		} break;
+		case kBgColorsChanged: {
+			const char* name;
+			if (message->FindString("name", &name) == B_OK) {
+				uint32 new_color;
+				if (message->FindUInt32("color", &new_color) == B_OK) {
+					if (strcmp(name, "color1") == 0)
+						fColor1 = new_color;
+					else
+						fColor2 = new_color;
+
+					_Update();
+				}
+			}
+		} break;
+		case kBgRevertToDefaults: {
+			_SetDefaults();
+			fGridSizeControl->SetValue(fGridSize);
+			_Update();
+		} break;
+		default: {
+			BView::MessageReceived(message);
+		}	break;
+	}
+}
+
+
+void
+GlobalSetupWindow::BackgroundControlView::ApplyChanges()
+{
+	if (SettingsServer* server = SettingsServer::Instance()) {
+		server->SetValue(SettingsServer::Application, skBgGridSize,
+			fGridSize);
+		server->SetValue(SettingsServer::Application, skBgColor1,
+			fColor1);
+		server->SetValue(SettingsServer::Application, skBgColor2,
+			fColor2);
+	}
+
+	PaintWindow::Redraw();
+}
+
+
+void
+GlobalSetupWindow::BackgroundControlView::_Update()
+{
+	fColorSwatch1->SetColor(fColor1);
+	fColorSwatch2->SetColor(fColor2);
+	BitmapUtilities::CheckerBitmap(fBgContainer->previewBitmap(), fColor1, fColor2, fGridSize);
+	fBgContainer->Redraw();
+}
+
+
+void
+GlobalSetupWindow::BackgroundControlView::_SetDefaults()
+{
+	rgb_color color1, color2;
+	color1.red = color1.green = color1.blue = 0xBB;
+	color2.red = color2.green = color2.blue = 0x99;
+	color1.alpha = color2.alpha = 0xFF;
+	fColor1 = RGBColorToBGRA(color1);
+	fColor2 = RGBColorToBGRA(color2);
+	fGridSize = 20;
+}
+
+
+PreviewPane::PreviewPane(BRect frame)
+	: BView(frame, "previewpane", B_FOLLOW_NONE, B_WILL_DRAW)
+	, fPreviewBitmap(NULL)
+{
+	SetExplicitMinSize(BSize(frame.Width(), frame.Height()));
+	SetExplicitMaxSize(BSize(frame.Width(), frame.Height()));
+
+	frame.InsetBy(1.0, 1.0);
+	fPreviewBitmap = new BBitmap(BRect(0.0, 0.0, frame.Width(),
+		frame.Height()), B_RGBA32);
+}
+
+
+PreviewPane::~PreviewPane()
+{
+	delete fPreviewBitmap;
+}
+
+
+void
+PreviewPane::Draw(BRect updateRect)
+{
+	BView::Draw(updateRect);
+
+	SetHighColor(0, 0, 0, 255);
+	StrokeRect(Bounds());
+
+	DrawBitmap(fPreviewBitmap, BPoint(1.0, 1.0));
+}
+
+
+void PreviewPane::MessageReceived(BMessage* message)
+{
+	switch(message->what) {
+		default:
+			BView::MessageReceived(message);
+	}
+}
+
+
+ColorSwatch::ColorSwatch(BRect frame, const char* name)
+	: BControl(frame, "colorswatch", name, new BMessage(kBgColorsChanged),
+			B_FOLLOW_NONE, B_WILL_DRAW)
+	, fSwatchBitmap(NULL)
+	, fColor(0)
+{
+	SetExplicitMinSize(BSize(frame.Width(), frame.Height()));
+	SetExplicitMaxSize(BSize(frame.Width(), frame.Height()));
+
+	Message()->AddString("name", name);
+	Message()->AddUInt32("color", fColor);
+
+	frame.InsetBy(1.0, 1.0);
+	fSwatchBitmap = new BBitmap(BRect(0.0, 0.0, frame.Width(),
+		frame.Height()), B_RGBA32);
+}
+
+
+ColorSwatch::~ColorSwatch()
+{
+	delete fSwatchBitmap;
+}
+
+
+void
+ColorSwatch::Draw(BRect updateRect)
+{
+	BControl::Draw(updateRect);
+
+	SetHighColor(0, 0, 0, 255);
+	StrokeRect(Bounds());
+
+	BitmapUtilities::ClearBitmap(fSwatchBitmap, fColor);
+	DrawBitmap(fSwatchBitmap, BPoint(1.0, 1.0));
+}
+
+
+void ColorSwatch::MessageReceived(BMessage* message)
+{
+	switch(message->what) {
+		case B_PASTE: {
+			if (message->WasDropped()) {
+				BPoint dropPoint = ConvertFromScreen(message->DropPoint());
+				ssize_t size;
+				const void* data;
+				if (message->FindData("RGBColor", B_RGB_COLOR_TYPE, &data,
+					&size) == B_OK && size == sizeof(rgb_color)) {
+					rgb_color new_color;
+					memcpy((void*)(&new_color), data, size);
+					new_color.alpha = 0xFF;
+					SetColor(RGBColorToBGRA(new_color));
+					Message()->ReplaceUInt32("color", fColor);
+					Draw(Bounds());
+					Invoke();
+				}
+			}
+		} break;
+		default:
+			BControl::MessageReceived(message);
+	}
+}
+
+
+void
+ColorSwatch::SetColor(uint32 color)
+{
+	fColor = color;
+	Draw(Bounds());
+}
+
+
 // #pragma mark -- GlobalSetupWindow
 
 
@@ -514,6 +831,11 @@ GlobalSetupWindow::GlobalSetupWindow(const BPoint& leftTop)
 	fGeneralControlView = new GeneralControlView;
 	fTabView->AddTab(fGeneralControlView, tab);
 	tab->SetLabel(B_TRANSLATE("Miscellaneous"));
+
+	tab = new BTab();
+	fBackgroundControlView = new BackgroundControlView;
+	fTabView->AddTab(fBackgroundControlView, tab);
+	tab->SetLabel(B_TRANSLATE("Background"));
 
 	layout->AddView(fTabView);
 	layout->AddView(BGroupLayoutBuilder(B_HORIZONTAL, 10.0)
@@ -563,6 +885,9 @@ GlobalSetupWindow::MessageReceived(BMessage* message)
 			if (fGeneralControlView)
 				fGeneralControlView->ApplyChanges();
 
+			if (fBackgroundControlView)
+				fBackgroundControlView->ApplyChanges();
+
 		// fall through
 		case kCloseAndDiscardSettings:
 			Quit();
@@ -573,6 +898,7 @@ GlobalSetupWindow::MessageReceived(BMessage* message)
 		}	break;
 	}
 }
+
 
 void
 GlobalSetupWindow::ShowGlobalSetupWindow()

--- a/artpaint/windows/GlobalSetupWindow.h
+++ b/artpaint/windows/GlobalSetupWindow.h
@@ -12,6 +12,7 @@
 #define GLOBAL_SETUP_WINDOW_H
 
 
+#include <Control.h>
 #include <Window.h>
 
 
@@ -39,8 +40,49 @@ private:
 	class	GeneralControlView;
 			GeneralControlView*		fGeneralControlView;
 
+	class	BackgroundControlView;
+			BackgroundControlView*	fBackgroundControlView;
+
+
 			BTabView*				fTabView;
 	static	GlobalSetupWindow*		fSetupWindow;
+};
+
+
+class PreviewPane : public BView {
+public:
+				PreviewPane(BRect frame);
+	virtual		~PreviewPane();
+
+	virtual void 	Draw(BRect updateRect);
+	virtual void	MessageReceived(BMessage* message);
+
+	BBitmap*	previewBitmap() { return fPreviewBitmap; }
+
+	void		Redraw() { Draw(Bounds()); }
+
+private:
+	BBitmap*	fPreviewBitmap;
+};
+
+
+class ColorSwatch : public BControl {
+public:
+				ColorSwatch(BRect frame, const char* name);
+	virtual		~ColorSwatch();
+
+	virtual void 	Draw(BRect updateRect);
+	virtual void	MessageReceived(BMessage* message);
+
+	BBitmap*	swatchBitmap() { return fSwatchBitmap; }
+
+	void		Redraw() { Draw(Bounds()); }
+
+	void		SetColor(uint32 new_color);
+	uint32		Color() { return fColor; }
+private:
+	BBitmap*	fSwatchBitmap;
+	uint32		fColor;
 };
 
 

--- a/artpaint/windows/GlobalSetupWindow.h
+++ b/artpaint/windows/GlobalSetupWindow.h
@@ -73,6 +73,7 @@ public:
 
 	virtual void 	Draw(BRect updateRect);
 	virtual void	MessageReceived(BMessage* message);
+	virtual void	MouseDown(BPoint point);
 
 	BBitmap*	swatchBitmap() { return fSwatchBitmap; }
 

--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.artpaint	3843079219
+1	English	application/x-vnd.artpaint	640123077
 Inserts text into the active layer. Same as the text tool.	PaintWindow		Inserts text into the active layer. Same as the text tool.
 Angle:	Manipulators		Angle:
 Cancel	Windows		Cancel
@@ -28,7 +28,6 @@ Creates a new empty canvas.	PaintWindow		Creates a new empty canvas.
 ArtPaint	System name		ArtPaint
 Airbrush tool	Tools		Airbrush tool
 Click to blur the image.	Tools		Click to blur the image.
-Color 1	Windows		Color 1
 Rectangle tool	Tools		Rectangle tool
 Not enough free memory to start the effect you requested. You may close other images and try again. Also shortening the depth of undo or disabling undo altogether helps in achieving more memory. If you have other applications running, closing them gives you more free memory. It is also a good idea to save your work at this point, because if the memory runs out completely saving might become impossible. I am very sorry about this inconvenience.	ImageView		Not enough free memory to start the effect you requested. You may close other images and try again. Also shortening the depth of undo or disabling undo altogether helps in achieving more memory. If you have other applications running, closing them gives you more free memory. It is also a good idea to save your work at this point, because if the memory runs out completely saving might become impossible. I am very sorry about this inconvenience.
 Click to draw a straight line.	Tools		Click to draw a straight line.
@@ -67,7 +66,6 @@ Flow:	Tools		Flow:
 Picking a color.	Tools		Picking a color.
 Making a selection.	Tools		Making a selection.
 Opens a project from disk.	PaintWindow		Opens a project from disk.
-Background	Windows		Background
 Change transparency…	Manipulators		Change transparency…
 New color set	ColorPalette		New color set
 Cut	PaintWindow		Cut
@@ -107,6 +105,7 @@ Click to make a fill.	Tools		Click to make a fill.
 Save project	PaintWindow		Save project
 Use the handles or number-fields to set the new borders.	Manipulators		Use the handles or number-fields to set the new borders.
 Spray	Tools		Spray
+Colors:	Windows		Colors:
 None	Tools		None
 Save format:	FilePanels		Save format:
 Clears all layers.	PaintWindow		Clears all layers.
@@ -119,7 +118,6 @@ Scale…	PaintWindow		Scale…
 Opens the main documentation for ArtPaint.	PaintWindow		Opens the main documentation for ArtPaint.
 Rotate…	Manipulators		Rotate…
 {0, plural,one{%project_name%: You have made a change since the last time the project was saved.\nDo you want to save the change?}other{%project_name%: You have made # changes since the last time the project was saved.\nDo you want to save the changes?}}	ImageView		{0, plural,one{%project_name%: You have made a change since the last time the project was saved.\nDo you want to save the change?}other{%project_name%: You have made # changes since the last time the project was saved.\nDo you want to save the changes?}}
-Grid Size	Windows		Grid Size
 Size:	Manipulators		Size:
 Color set	ColorPalette		Color set
 Fill ellipse	Tools		Fill ellipse
@@ -151,6 +149,7 @@ Green	Tools		Green
 Store brush	Tools		Store brush
 Painting with a hairy brush.	Tools		Painting with a hairy brush.
 Edit	PaintWindow		Edit
+Drop a color from the Colors window	Windows		Drop a color from the Colors window
 Drawing an ellipse.	Tools		Drawing an ellipse.
 Straight line tool	Tools		Straight line tool
 Shrink selection	ImageView		Shrink selection
@@ -211,7 +210,6 @@ Rotates all layers 90° counter-clockwise.	PaintWindow		Rotates all layers 90° 
 Invert selection	PaintWindow		Invert selection
 Not enough free memory to add a layer .You can free more memory by disabling the undo and closing other images. It is also a good idea to save the image now because running out of memory later on might make saving difficult or impossible. I am very sorry about this inconvenience.	ImageView		Not enough free memory to add a layer .You can free more memory by disabling the undo and closing other images. It is also a good idea to save the image now because running out of memory later on might make saving difficult or impossible. I am very sorry about this inconvenience.
 Brush	Windows		Brush
-Color 2	Windows		Color 2
 Hairy brush tool	Tools		Hairy brush tool
 Blur tool	Tools		Blur tool
 Adjustable	Windows		Adjustable
@@ -227,7 +225,6 @@ Translate…	Manipulators		Translate…
 Cannot write to file	ColorPalette		Cannot write to file
 Delete current set	ColorPalette		Delete current set
 Merge with front layer	LayerView		Merge with front layer
-Revert	Windows		Revert
 Closes the current window.	PaintWindow		Closes the current window.
 Click to draw a rectangle.	Tools		Click to draw a rectangle.
 Duplicate layer	LayerView		Duplicate layer
@@ -260,6 +257,7 @@ Cuts the selection to the clipboard.	PaintWindow		Cuts the selection to the clip
 Rotation:	Manipulators		Rotation:
 Ellipse tool	Tools		Ellipse tool
 Add layer in front	LayerView		Add layer in front
+Defaults	Windows		Defaults
 Create canvas	PaintWindow		Create canvas
 Replace pixels with	Tools		Replace pixels with
 Delete layer	Image		Delete layer
@@ -290,6 +288,7 @@ Behavior	Tools		Behavior
 Grow selection	PaintWindow		Grow selection
 Flood fill	Tools		Flood fill
 ArtPaint is a painting and image-processing program for Haiku.	PaintApplication		ArtPaint is a painting and image-processing program for Haiku.
+Grid size:	Windows		Grid size:
 Adds a layer to the top of this image.	PaintWindow		Adds a layer to the top of this image.
 Sets the zoom level to 400%.	PaintWindow		Sets the zoom level to 400%.
 OK	ImageView		OK
@@ -302,6 +301,7 @@ Sets the grid to 4 by 4 pixels.	PaintWindow		Sets the grid to 4 by 4 pixels.
 User manual…	PaintWindow		User manual…
 Corner to corner	Tools		Corner to corner
 Opens the layers window.	PaintWindow		Opens the layers window.
+Transparency	Windows		Transparency
 Selection tool	Tools		Selection tool
 Add layer	Image		Add layer
 Enable gradient	Tools		Enable gradient
@@ -353,6 +353,5 @@ Tools…	PaintWindow		Tools…
 Add area	Tools		Add area
 Hardness:	Tools		Hardness:
 Scales the image.	PaintWindow		Scales the image.
-Drag color from palette to set	Windows		Drag color from palette to set
 Recent images	PaintWindow		Recent images
 Color picker tool	Tools		Color picker tool

--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.artpaint	1463313598
+1	English	application/x-vnd.artpaint	3843079219
 Inserts text into the active layer. Same as the text tool.	PaintWindow		Inserts text into the active layer. Same as the text tool.
 Angle:	Manipulators		Angle:
 Cancel	Windows		Cancel
@@ -28,6 +28,7 @@ Creates a new empty canvas.	PaintWindow		Creates a new empty canvas.
 ArtPaint	System name		ArtPaint
 Airbrush tool	Tools		Airbrush tool
 Click to blur the image.	Tools		Click to blur the image.
+Color 1	Windows		Color 1
 Rectangle tool	Tools		Rectangle tool
 Not enough free memory to start the effect you requested. You may close other images and try again. Also shortening the depth of undo or disabling undo altogether helps in achieving more memory. If you have other applications running, closing them gives you more free memory. It is also a good idea to save your work at this point, because if the memory runs out completely saving might become impossible. I am very sorry about this inconvenience.	ImageView		Not enough free memory to start the effect you requested. You may close other images and try again. Also shortening the depth of undo or disabling undo altogether helps in achieving more memory. If you have other applications running, closing them gives you more free memory. It is also a good idea to save your work at this point, because if the memory runs out completely saving might become impossible. I am very sorry about this inconvenience.
 Click to draw a straight line.	Tools		Click to draw a straight line.
@@ -66,6 +67,7 @@ Flow:	Tools		Flow:
 Picking a color.	Tools		Picking a color.
 Making a selection.	Tools		Making a selection.
 Opens a project from disk.	PaintWindow		Opens a project from disk.
+Background	Windows		Background
 Change transparency…	Manipulators		Change transparency…
 New color set	ColorPalette		New color set
 Cut	PaintWindow		Cut
@@ -117,6 +119,7 @@ Scale…	PaintWindow		Scale…
 Opens the main documentation for ArtPaint.	PaintWindow		Opens the main documentation for ArtPaint.
 Rotate…	Manipulators		Rotate…
 {0, plural,one{%project_name%: You have made a change since the last time the project was saved.\nDo you want to save the change?}other{%project_name%: You have made # changes since the last time the project was saved.\nDo you want to save the changes?}}	ImageView		{0, plural,one{%project_name%: You have made a change since the last time the project was saved.\nDo you want to save the change?}other{%project_name%: You have made # changes since the last time the project was saved.\nDo you want to save the changes?}}
+Grid Size	Windows		Grid Size
 Size:	Manipulators		Size:
 Color set	ColorPalette		Color set
 Fill ellipse	Tools		Fill ellipse
@@ -208,6 +211,7 @@ Rotates all layers 90° counter-clockwise.	PaintWindow		Rotates all layers 90° 
 Invert selection	PaintWindow		Invert selection
 Not enough free memory to add a layer .You can free more memory by disabling the undo and closing other images. It is also a good idea to save the image now because running out of memory later on might make saving difficult or impossible. I am very sorry about this inconvenience.	ImageView		Not enough free memory to add a layer .You can free more memory by disabling the undo and closing other images. It is also a good idea to save the image now because running out of memory later on might make saving difficult or impossible. I am very sorry about this inconvenience.
 Brush	Windows		Brush
+Color 2	Windows		Color 2
 Hairy brush tool	Tools		Hairy brush tool
 Blur tool	Tools		Blur tool
 Adjustable	Windows		Adjustable
@@ -223,6 +227,7 @@ Translate…	Manipulators		Translate…
 Cannot write to file	ColorPalette		Cannot write to file
 Delete current set	ColorPalette		Delete current set
 Merge with front layer	LayerView		Merge with front layer
+Revert	Windows		Revert
 Closes the current window.	PaintWindow		Closes the current window.
 Click to draw a rectangle.	Tools		Click to draw a rectangle.
 Duplicate layer	LayerView		Duplicate layer
@@ -348,5 +353,6 @@ Tools…	PaintWindow		Tools…
 Add area	Tools		Add area
 Hardness:	Tools		Hardness:
 Scales the image.	PaintWindow		Scales the image.
+Drag color from palette to set	Windows		Drag color from palette to set
 Recent images	PaintWindow		Recent images
 Color picker tool	Tools		Color picker tool


### PR DESCRIPTION
Cleaned up and finished patch for alpha checker background

- Added checkerboard alpha background to main window and layer thumbnails
- Added mode to render with the white bg (needed to properly save files)
- Added settings tab to Global settings to allow different grid sizes and colors
- Updated SettingServer to check for != B_ERROR instead of B_OK - this is because
if a setting doesn't exist the check will fail, so it's impossible to add new
settings.

Fixes #63