### PR TITLE
Settings window: Layout changes

### DIFF
--- a/artpaint/windows/GlobalSetupWindow.cpp
+++ b/artpaint/windows/GlobalSetupWindow.cpp
@@ -852,6 +852,12 @@ GlobalSetupWindow::GlobalSetupWindow(const BPoint& leftTop)
 		settings.FindInt32(skSettingsWindowTab, &activeTab);
 	}
 	fTabView->Select(activeTab);
+
+	float width = 0;
+	for (int i = 0; i < fTabView->CountTabs(); i++)
+		width += fTabView->TabFrame(i).Width();
+
+	fTabView->SetExplicitMinSize(BSize(width + 2 * be_plain_font->Size(), B_SIZE_UNSET));
 }
 
 

--- a/artpaint/windows/GlobalSetupWindow.h
+++ b/artpaint/windows/GlobalSetupWindow.h
@@ -37,11 +37,11 @@ private:
 	class	UndoControlView;
 			UndoControlView*		fUndoControlView;
 
-	class	GeneralControlView;
-			GeneralControlView*		fGeneralControlView;
+	class	TransparencyControlView;
+			TransparencyControlView*	fTransparencyControlView;
 
-	class	BackgroundControlView;
-			BackgroundControlView*	fBackgroundControlView;
+	class	MiscControlView;
+			MiscControlView*		fMiscControlView;
 
 
 			BTabView*				fTabView;


### PR DESCRIPTION
* Rename *ControlViews to reflect their tab view labels and
  move them in the same order as the tab views in te GUI.
* Use BLayoutBuilder templates everywhere.
* Use consistent inset/spacing constants instead of hardcoded values.
* Remove insets around the tab view to avoid wasting space.
* Windows tab: alpha-sort the radio-buttons
* Transparency:
  - Use font size as measure for the background preview size and
    colour swatches.
  - Make the colour swatches a bit smaller and put them side-by-side.
  - Switch rows for "Colors" and "Grid size". Looks better and
    makes space for the...
  - "Defaults" button on the right side