### PR TITLE
TextManipulator: Fix layout

### DIFF
--- a/artpaint/viewmanipulators/TextManipulator.cpp
+++ b/artpaint/viewmanipulators/TextManipulator.cpp
@@ -600,45 +600,45 @@ TextManipulatorView::TextManipulatorView(TextManipulator* manipulator,
 			}
 		}
 	}
-	fFontMenuField = new BMenuField(B_TRANSLATE("Font"),
+	fFontMenuField = new BMenuField(B_TRANSLATE("Font:"),
 		fFontMenu);
 
 	BMessage *message = new BMessage(FONT_SIZE_CHANGED);
 	fSizeControl =
 		new NumberSliderControl(B_TRANSLATE("Size:"), "0",
 		message, 5, 500, false);
-	AddChild(fSizeControl);
 
 	message = new BMessage(FONT_ROTATION_CHANGED);
 	fRotationControl =
 		new NumberSliderControl(B_TRANSLATE("Rotation:"),
 		"0", message, -180, 180, false);
-	AddChild(fRotationControl);
 
 	message = new BMessage(FONT_SHEAR_CHANGED);
 	fShearControl =
 		new NumberSliderControl(B_TRANSLATE("Shear:"),
 		"45", message, 45, 135, false);
-	AddChild(fShearControl);
 
 	fAntiAliasing =
 		new BCheckBox(B_TRANSLATE("Enable antialiasing"),
 		new BMessage(FONT_ANTI_ALIAS_CHANGED));
 
-	BGridLayout* layout = BGridLayoutBuilder(5.0, 5.0)
+	BGridLayout* layout = BGridLayoutBuilder(B_USE_SMALL_SPACING, B_USE_SMALL_SPACING)
+		.Add(fSizeControl, 0, 0, 0, 0)
 		.Add(fSizeControl->LabelLayoutItem(), 0, 0)
 		.Add(fSizeControl->TextViewLayoutItem(), 1, 0)
 		.Add(fSizeControl->Slider(), 2, 0)
+		.Add(fRotationControl, 0, 0, 0, 0)
 		.Add(fRotationControl->LabelLayoutItem(), 0, 1)
 		.Add(fRotationControl->TextViewLayoutItem(), 1, 1)
 		.Add(fRotationControl->Slider(), 2, 1)
+		.Add(fShearControl, 0, 0, 0, 0)
 		.Add(fShearControl->LabelLayoutItem(), 0, 2)
 		.Add(fShearControl->TextViewLayoutItem(), 1, 2)
 		.Add(fShearControl->Slider(), 2, 2);
 	layout->SetMaxColumnWidth(1, fTextView->StringWidth("1000"));
 
 	SetLayout(new BGroupLayout(B_VERTICAL));
-	AddChild(BGroupLayoutBuilder(B_VERTICAL, 5.0)
+	AddChild(BGroupLayoutBuilder(B_VERTICAL, B_USE_SMALL_SPACING)
 		.Add(new BBox(B_FANCY_BORDER, fTextView))
 		.Add(fFontMenuField)
 		.Add(layout->View())

--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,5 +1,4 @@
-1	English	application/x-vnd.artpaint	640123077
-Inserts text into the active layer. Same as the text tool.	PaintWindow		Inserts text into the active layer. Same as the text tool.
+1	English	application/x-vnd.artpaint	183125306
 Angle:	Manipulators		Angle:
 Cancel	Windows		Cancel
 Enable antialiasing	Manipulators		Enable antialiasing
@@ -78,7 +77,6 @@ Save image	PaintWindow		Save image
 Brush tool	Tools		Brush tool
 Cannot delete the only color set.	ColorPalette		Cannot delete the only color set.
 Redo	UndoQueue		Redo
-Font	Manipulators		Font
 Set grid	PaintWindow		Set grid
 Delete selected brush	Windows		Delete selected brush
 Saves the image to disk.	PaintWindow		Saves the image to disk.
@@ -129,6 +127,7 @@ Ellipse	Tools		Ellipse
 Adjustable width	Tools		Adjustable width
 Transparency:	Manipulators		Transparency:
 Shear:	Manipulators		Shear:
+Font:	Manipulators		Font:
 Redo not available	PaintWindow		Redo not available
 Opens the settings window.	PaintWindow		Opens the settings window.
 Unlimited	Windows		Unlimited
@@ -141,7 +140,6 @@ Speed:	Tools		Speed:
 Close	PaintWindow		Close
 Click to place the text.	Tools		Click to place the text.
 Translate…	PaintWindow		Translate…
-Insert text…	PaintWindow		Insert text…
 Shrinks the selection in all directions.	PaintWindow		Shrinks the selection in all directions.
 Text tool	Tools		Text tool
 Open project…	PaintWindow		Open project…
@@ -159,8 +157,8 @@ Inverts the selection	PaintWindow		Inverts the selection
 Enable antialiasing	Tools		Enable antialiasing
 Turns the grid off.	PaintWindow		Turns the grid off.
 Undo	Windows		Undo
-Airbrush	Tools		Airbrush
 Not enough free memory to create the image. Please try again with a smaller image size.	PaintWindow		Not enough free memory to create the image. Please try again with a smaller image size.
+Airbrush	Tools		Airbrush
 Height:	Manipulators		Height:
 Sets the grid to 2 by 2 pixels.	PaintWindow		Sets the grid to 2 by 2 pixels.
 Reset brush	Tools		Reset brush
@@ -186,6 +184,7 @@ Enable preview	Tools		Enable preview
 Moves the active layer.	PaintWindow		Moves the active layer.
 Undos the previous action.	PaintWindow		Undos the previous action.
 Rotate -90°	Manipulators		Rotate -90°
+Application	Windows		Application
 Standard sizes	PaintWindow		Standard sizes
 Datatype setup: %name%	Windows		Datatype setup: %name%
 Options	Tools		Options
@@ -315,8 +314,8 @@ Canvas	PaintWindow		Canvas
 Transparency tool	Tools		Transparency tool
 Choose format	FilePanels		Choose format
 Cancel	FilePanels		Cancel
-Mode	Tools		Mode
 Flip horizontally	PaintWindow		Flip horizontally
+Mode	Tools		Mode
 Change transparency…	PaintWindow		Change transparency…
 Bottom:	Manipulators		Bottom:
 Hold shift key to snap to 45° angles	Tools		Hold shift key to snap to 45° angles


### PR DESCRIPTION
Don't AddChild() the NumberSliderControls to the view or they'll
add some empty spacing at the top of the window. Instead, hide
them in the layout.
Use spacing constants instead of hardcoded values.