### PR TITLE
Brush Tool: check for NULL brush_matrix in draw_brush function

### DIFF
--- a/artpaint/tools/Brush.cpp
+++ b/artpaint/tools/Brush.cpp
@@ -191,6 +191,8 @@ Brush::GetData(span **sp,int32 dx,int32 dy)
 			return diff_11;
 		}
 	}
+
+	*sp = NULL;
 	return NULL;
 }
 

--- a/artpaint/tools/BrushTool.cpp
+++ b/artpaint/tools/BrushTool.cpp
@@ -293,6 +293,9 @@ BrushTool::draw_brush(BBitmap* buffer, BPoint point,
 	int32 py = (int32)point.y;
 	uint32** brush_matrix = brush->GetData(&spans, dx, dy);
 
+	if (brush_matrix == NULL)
+		return;
+
 	bits = (uint32*)buffer->Bits();
 	uint32* target_bits = bits;
 	while ((spans != NULL) && (spans->row + py <= bottom_bound)) {


### PR DESCRIPTION
The function call to brush->GetData returns NULL if the dx and dy are out of range.  The code checks if the spans returned are NULL, but never checks if the brush_matrix is NULL.  Also set spans to NULL when returning NULL from Brush::GetData()

Fixes #212