### PR TITLE
Build fix: set template arguments for std::pair

### DIFF
--- a/artpaint/paintwindow/PaintWindow.cpp
+++ b/artpaint/paintwindow/PaintWindow.cpp
@@ -1431,7 +1431,7 @@ PaintWindow::_AddAddOnsToMenu(void* data)
 							Manipulator *manipulator = Instantiate(NULL, NULL);
 
 							if (manipulator != NULL) {
-								manip_map.insert(std::pair(BString(manipulator->ReturnName()), *it));
+								manip_map.insert(std::pair<BString, int32>(BString(manipulator->ReturnName()), *it));
 
 								delete manipulator;
 								manipulator = NULL;


### PR DESCRIPTION
Fix build issue for 2.3.0 32-bit build...

...but what's different about the 64-bit build?  Is it more permissive?  