### PR TITLE
Global Settings: use width of localized "Grid size" string to set minimum window size

### DIFF
--- a/artpaint/windows/GlobalSetupWindow.cpp
+++ b/artpaint/windows/GlobalSetupWindow.cpp
@@ -857,7 +857,9 @@ GlobalSetupWindow::GlobalSetupWindow(const BPoint& leftTop)
 	for (int i = 0; i < fTabView->CountTabs(); i++)
 		width += fTabView->TabFrame(i).Width();
 
-	fTabView->SetExplicitMinSize(BSize(width + 2 * be_plain_font->Size(), B_SIZE_UNSET));
+	width += be_plain_font->StringWidth(B_TRANSLATE("Grid size:"));
+
+	fTabView->SetExplicitMinSize(BSize(width, B_SIZE_UNSET));
 }
 
 


### PR DESCRIPTION
Feels a bit arbitrary, but it works.

Fixes #230 