### PR TITLE
AntiDitherer addon: Deleted blank lines in pt.catkeys

### DIFF
--- a/addons/AddOns/AntiDitherer/locales/pt.catkeys
+++ b/addons/AddOns/AntiDitherer/locales/pt.catkeys
@@ -3,7 +3,4 @@ Anti-Dither	AddOns_AntiDither		Anti-pontilhamento
 Anti-Dither…	AddOns_AntiDither		Anti-Dither…
 Attempts to reverse the effects of dithering.	AddOns_AntiDither		Tentativas de reverter os efeitos da dilatação.
 Block size:	AddOns_AntiDither		tamanho do bloco:
-
-
 Reduce resolution	AddOns_AntiDither		Reduzir a resolução
-


### PR DESCRIPTION
Portugese catkeys file had blank lines that were causing a "Bad data" error during build. 