### PR TITLE
ColorPalette: add hex color field

### DIFF
--- a/artpaint/controls/CMYColorControl.h
+++ b/artpaint/controls/CMYColorControl.h
@@ -62,7 +62,7 @@ CMYColorControl::rgb2cmyk(float r, float g, float b,
 	b /= 255.;
 
 	k = 1.0 - max_c(r, max_c(g, b));
-	float inv_k = 1.0 - k; // + 0.00001;
+	float inv_k = 1.0 - k + 0.00001;  // guard against divide-by-zero
 	c = ((1.0 - r - k) / inv_k) * 100.;
  	m = ((1.0 - g - k) / inv_k) * 100.;
  	y = ((1.0 - b - k) / inv_k) * 100.;

--- a/artpaint/controls/ColorPalette.h
+++ b/artpaint/controls/ColorPalette.h
@@ -24,6 +24,7 @@
 #include <ColorControl.h>
 #include <FilePanel.h>
 #include <PictureButton.h>
+#include <TextControl.h>
 #include <Window.h>
 
 
@@ -35,6 +36,7 @@ class PaletteWindowClient;
 
 
 #define COLOR_CHIP_INVOKED			'ccIn'
+#define HEX_COLOR_EDITED			'hcEd'
 
 
 // we have to derive the BColorControl-class just to get
@@ -96,6 +98,9 @@ static	BList*					palette_window_clients;
 		HSVColorControl* 		hsvSlider;
 
 		ColorChip*				colorPreview;
+		BTextControl*			hexColorField;
+
+		void					SetHexColor(const rgb_color c);
 // This static holds the pointer to the open palette-window.
 // If no window is open, it is NULL
 static	ColorPaletteWindow*		palette_window;


### PR DESCRIPTION
Added text control below color well in color palette window. Accepts:
- with or without '#'
- 3 digits, like html - assumes alpha of FF -- '123' -> '#112233FF'
- 4 digits, as above but with alpha -- '1234' -> '#11223344'
- 6 digits - assumes alpha of FF -- '123456' -> '#123456FF'
- 8 digits -- '12345678' -> '#12345678'

One caveat: setting the hex color via text does NOT update the selected color in the main window.  The problem is that ArtPaint uses whichever button was used to click on the wells and sliders to decide whether to update the fg or bg color, and in this case we have no button information.  I didn't want to assume that the user always wants to edit the fg color. After you type in (or copy/paste) a hex value, you can either right- or left-click on the palette entry.  

Fixes #256 