### PR TITLE
ToolWindow: add stroke to selected tool button to make it more obvious

### DIFF
--- a/artpaint/tools/ToolButton.cpp
+++ b/artpaint/tools/ToolButton.cpp
@@ -106,6 +106,14 @@ ToolButton::Draw(BRect updateRect)
 			SetDrawingMode(B_OP_ALPHA);
 			DrawBitmap(fIcon, BPoint(gInset, gInset));
 		}
+
+		if (Value() & B_CONTROL_ON) {
+			SetHighColor(ui_color(B_KEYBOARD_NAVIGATION_COLOR));
+			BRect buttonFrame = Bounds();
+			StrokeRect(buttonFrame);
+			buttonFrame.InsetBy(1, 1);
+			StrokeRect(buttonFrame);
+		}
 	} else {
 		SetHighColor(ui_color(B_PANEL_BACKGROUND_COLOR));
 		FillRect(Bounds());


### PR DESCRIPTION
Added border around selected tool using ui color B_KEYBOARD_NAVIGATION_COLOR - I tried different UI colors and this seemed the best compromise between visibility and obtrusiveness,  B_WINDOW_TAB_COLOR was too much, B_MENU_SELECTED_BACKGROUND_COLOR was still a bit subtle.  

Fixes #33 
