### PR TITLE
Alpha selection fix: Render transparent selections properly when transforming

### DIFF
--- a/artpaint/viewmanipulators/RotationManipulator.cpp
+++ b/artpaint/viewmanipulators/RotationManipulator.cpp
@@ -8,6 +8,7 @@
  *
  */
 
+#include "BitmapUtilities.h"
 #include "HSPolygon.h"
 #include "ImageView.h"
 #include "MessageConstants.h"
@@ -39,7 +40,7 @@
 #define PI M_PI
 
 
-RotationManipulator::RotationManipulator(BBitmap *bitmap)
+RotationManipulator::RotationManipulator(BBitmap* bitmap)
 	:	WindowGUIManipulator()
 {
 	settings = new RotationManipulatorSettings();
@@ -52,18 +53,17 @@ RotationManipulator::RotationManipulator(BBitmap *bitmap)
 	last_calculated_resolution = 0;
 
 	BPoint poly_points[8];
-	poly_points[0] = BPoint(-5,0);
-	poly_points[1] = BPoint(0,0);
-	poly_points[2] = BPoint(0,-5);
-	poly_points[3] = BPoint(0,0);
-	poly_points[4] = BPoint(5,0);
-	poly_points[5] = BPoint(0,0);
-	poly_points[6] = BPoint(0,5);
-	poly_points[7] = BPoint(0,0);
+	poly_points[0] = BPoint(-5, 0);
+	poly_points[1] = BPoint(0, 0);
+	poly_points[2] = BPoint(0, -5);
+	poly_points[3] = BPoint(0, 0);
+	poly_points[4] = BPoint(5, 0);
+	poly_points[5] = BPoint(0, 0);
+	poly_points[6] = BPoint(0, 5);
+	poly_points[7] = BPoint(0, 0);
 
-	view_polygon = new HSPolygon(poly_points,8);
+	view_polygon = new HSPolygon(poly_points, 8);
 }
-
 
 
 RotationManipulator::~RotationManipulator()
@@ -78,13 +78,15 @@ RotationManipulator::~RotationManipulator()
 }
 
 
-void RotationManipulator::SetPreviewBitmap(BBitmap *bitmap)
+void
+RotationManipulator::SetPreviewBitmap(BBitmap* bitmap)
 {
 	if (config_view != NULL) {
 		config_view->SetAngle(0.0);
 	}
 
-	if ((bitmap == NULL) || (preview_bitmap == NULL) || (bitmap->Bounds() != preview_bitmap->Bounds())) {
+	if ((bitmap == NULL) || (preview_bitmap == NULL) ||
+		(bitmap->Bounds() != preview_bitmap->Bounds())) {
 		try {
 			if (preview_bitmap != NULL) {
 				delete copy_of_the_preview_bitmap;
@@ -93,7 +95,9 @@ void RotationManipulator::SetPreviewBitmap(BBitmap *bitmap)
 				preview_bitmap = bitmap;
 				copy_of_the_preview_bitmap = DuplicateBitmap(preview_bitmap);
 				BRect bounds = preview_bitmap->Bounds();
-				settings->origo = BPoint((bounds.right-bounds.left)/2+bounds.left,(bounds.bottom-bounds.top)/2+bounds.top);
+				settings->origo = BPoint((bounds.right - bounds.left) / 2 +
+					bounds.left, (bounds.bottom - bounds.top) / 2 +
+					bounds.top);
 			}
 			else {
 				preview_bitmap = NULL;
@@ -102,7 +106,7 @@ void RotationManipulator::SetPreviewBitmap(BBitmap *bitmap)
 		}
 		catch (std::bad_alloc e) {
 			preview_bitmap = NULL;
-			copy_of_the_preview_bitmap=NULL;
+			copy_of_the_preview_bitmap = NULL;
 			throw e;
 		}
 	}
@@ -111,20 +115,22 @@ void RotationManipulator::SetPreviewBitmap(BBitmap *bitmap)
 		preview_bitmap = bitmap;
 		uint32 *source = (uint32*)preview_bitmap->Bits();
 		uint32 *target = (uint32*)copy_of_the_preview_bitmap->Bits();
-		int32 bitslength = min_c(preview_bitmap->BitsLength(),copy_of_the_preview_bitmap->BitsLength());
-		memcpy(target,source,bitslength);
+		int32 bitslength = min_c(preview_bitmap->BitsLength(),
+			copy_of_the_preview_bitmap->BitsLength());
+		memcpy(target, source, bitslength);
 	}
 
 	if (preview_bitmap != NULL) {
 		double speed = GetSystemClockSpeed() / 15000;
 
 		BRect bounds = preview_bitmap->Bounds();
-		float num_pixels = (bounds.Width()+1) * (bounds.Height() + 1);
+		float num_pixels = (bounds.Width() + 1) * (bounds.Height() + 1);
 		lowest_available_quality = 1;
-		while ((2*num_pixels/lowest_available_quality/lowest_available_quality) > speed)
+		while ((2 * num_pixels / lowest_available_quality /
+			lowest_available_quality) > speed)
 			lowest_available_quality *= 2;
 
-		highest_available_quality = max_c(lowest_available_quality/2,1);
+		highest_available_quality = max_c(lowest_available_quality / 2, 1);
 	}
 	else {
 		lowest_available_quality = 1;
@@ -134,25 +140,33 @@ void RotationManipulator::SetPreviewBitmap(BBitmap *bitmap)
 }
 
 
-BRegion RotationManipulator::Draw(BView *view,float mag_scale)
+BRegion
+RotationManipulator::Draw(BView* view, float mag_scale)
 {
 	float x = settings->origo.x;
 	float y = settings->origo.y;
 
-	view->StrokeLine(BPoint(mag_scale*x-10,mag_scale*y),BPoint(mag_scale*x+10,mag_scale*y),B_MIXED_COLORS);
-	view->StrokeLine(BPoint(mag_scale*x,mag_scale*y-10),BPoint(mag_scale*x,mag_scale*y+10),B_MIXED_COLORS);
-	view->StrokeEllipse(BRect(BPoint(mag_scale*x-5,mag_scale*y-5),BPoint(mag_scale*x+5,mag_scale*y+5)),B_MIXED_COLORS);
+	view->StrokeLine(BPoint(mag_scale * x - 10, mag_scale * y),
+		BPoint(mag_scale * x + 10, mag_scale * y), B_MIXED_COLORS);
+	view->StrokeLine(BPoint(mag_scale * x, mag_scale * y - 10),
+		BPoint(mag_scale * x, mag_scale * y + 10), B_MIXED_COLORS);
+	view->StrokeEllipse(BRect(BPoint(mag_scale * x - 5, mag_scale * y - 5),
+		BPoint(mag_scale * x + 5, mag_scale * y + 5)), B_MIXED_COLORS);
 
 	BRegion updated_region;
-	updated_region.Set(BRect(mag_scale*x-10,mag_scale*y-10,mag_scale*x+10,mag_scale*y+10));
+	updated_region.Set(BRect(mag_scale * x - 10, mag_scale * y - 10,
+		mag_scale * x + 10, mag_scale * y + 10));
 	return updated_region;
 }
 
 
-void RotationManipulator::MouseDown(BPoint point,uint32 buttons,BView*,bool first_click)
+void
+RotationManipulator::MouseDown(BPoint point, uint32 buttons, BView*, bool first_click)
 {
 	if (first_click == TRUE) {
-		if (!(buttons & B_PRIMARY_MOUSE_BUTTON) || ((fabs(point.x-settings->origo.x)<10) && (fabs(point.y-settings->origo.y)<10)))
+		if (!(buttons & B_PRIMARY_MOUSE_BUTTON) ||
+			((fabs(point.x - settings->origo.x) < 10) &&
+			(fabs(point.y - settings->origo.y) < 10)))
 			move_origo = TRUE;
 		else
 			move_origo = FALSE;
@@ -165,7 +179,7 @@ void RotationManipulator::MouseDown(BPoint point,uint32 buttons,BView*,bool firs
 
 		float dy = point.y - settings->origo.y;
 		float dx = point.x - settings->origo.x;
-		new_angle = atan2(dy,dx);
+		new_angle = atan2(dy, dx);
 		new_angle = new_angle / PI *180;
 		if (first_click == TRUE) {
 			starting_angle = new_angle;
@@ -188,11 +202,14 @@ void RotationManipulator::MouseDown(BPoint point,uint32 buttons,BView*,bool firs
 }
 
 
-BBitmap* RotationManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap*
+RotationManipulator::ManipulateBitmap(ManipulatorSettings* set, BBitmap* original,
+	Selection* selection, BStatusBar* status_bar)
 {
 	// Here move the contents of the original-bitmap to the new_bitmap,
 	// rotated by s->angle around s->origin.
-	RotationManipulatorSettings *new_settings = cast_as(set,RotationManipulatorSettings);
+	RotationManipulatorSettings* new_settings = cast_as(set,
+		RotationManipulatorSettings);
 	if (new_settings == NULL)
 		return NULL;
 
@@ -202,11 +219,11 @@ BBitmap* RotationManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap 
 	if (new_settings->angle == 0)
 		return NULL;
 
-	BBitmap *new_bitmap;
+	BBitmap* new_bitmap;
 	if (original != preview_bitmap) {
 		original->Lock();
 		BRect bitmap_frame = original->Bounds();
-		new_bitmap = new BBitmap(bitmap_frame,B_RGB32);
+		new_bitmap = new BBitmap(bitmap_frame, B_RGB32);
 		original->Unlock();
 		if (new_bitmap->IsValid() == FALSE)
 			throw std::bad_alloc();
@@ -226,13 +243,13 @@ BBitmap* RotationManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap 
 	BPoint center = new_settings->origo;
 
 	float the_angle = new_settings->angle;
-	float sin_angle = sin(-the_angle/360*2*PI);
-	float cos_angle = cos(-the_angle/360*2*PI);
+	float sin_angle = sin(-the_angle / 360 * 2 * PI);
+	float cos_angle = cos(-the_angle / 360 * 2 * PI);
 
 	int32 *target_bits = (int32*)new_bitmap->Bits();
 	int32 *source_bits = (int32*)original->Bits();
-	int32 source_bpr = original->BytesPerRow()/4;
-	int32 target_bpr = new_bitmap->BytesPerRow()/4;
+	int32 source_bpr = original->BytesPerRow() / 4;
+	int32 target_bpr = new_bitmap->BytesPerRow() / 4;
 
 	// copy the points according to angle
 	float height = new_bitmap->Bounds().Height();
@@ -244,21 +261,19 @@ BBitmap* RotationManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap 
 	float center_x = center.x;
 	float center_y = center.y;
 	float source_x,source_y;
-	float y_times_sin = (-center_y)*sin_angle;
-	float y_times_cos = (-center_y)*cos_angle;
+	float y_times_sin = (-center_y) * sin_angle;
+	float y_times_cos = (-center_y) * cos_angle;
 
-	BWindow *status_bar_window = status_bar->Window();
+	BWindow* status_bar_window = status_bar->Window();
 
-	float red,green,blue,alpha;	// before optimization was int32
+	float red, green, blue, alpha;	// before optimization was int32
 
-	float floor_x,ceil_x,floor_y,ceil_y;	// was int32 before optimization
+	float floor_x, ceil_x, floor_y, ceil_y;	// was int32 before optimization
 
-	uint32 p1,p2,p3,p4;
+	uint32 p1, p2, p3, p4;
 
-	union {
-		uint8	bytes[4];
-		uint32	word;
-	} background;
+	union color_conversion background;
+
 	// Transparent background.
 	background.bytes[0] = 0xFF;
 	background.bytes[1] = 0xFF;
@@ -266,10 +281,10 @@ BBitmap* RotationManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap 
 	background.bytes[3] = 0x00;
 
 	if (selection->IsEmpty()) {
-		for (float y=0;y<=height;y++) {
-			float x_times_sin = (-center_x)*sin_angle;
-			float x_times_cos = (-center_x)*cos_angle;
-			for (float x=0;x<=width;x++) {
+		for (float y = 0; y <= height; y++) {
+			float x_times_sin = (-center_x) * sin_angle;
+			float x_times_cos = (-center_x) * cos_angle;
+			for (float x = 0; x <= width; x++) {
 				// rotate here around the origin
 				source_x = x_times_cos - y_times_sin;
 				source_y = x_times_sin + y_times_cos;
@@ -287,85 +302,77 @@ BBitmap* RotationManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap 
 				float u = source_x - floor_x;
 				float v = source_y - floor_y;
 				// Then add the weighted sums of the four pixels.
-				if ((	floor_x <= right) && (floor_y <= bottom)
-						&& (floor_x>=left) && (floor_y>=top)) {
-					p1 = *(source_bits + (int32)floor_x + (int32)floor_y*source_bpr);
+				if ((floor_x <= right) && (floor_y <= bottom) &&
+					(floor_x >= left) && (floor_y >= top)) {
+					p1 = *(source_bits + (int32)floor_x +
+						(int32)floor_y * source_bpr);
 				}
-				else {
+				else
 					p1 = background.word;
-				}
 
-				if ((	ceil_x <= right) && (floor_y <= bottom)
-						&& (ceil_x>=left) && (floor_y>=top)) {
-					p2 = *(source_bits + (int32)ceil_x + (int32)floor_y*source_bpr);
-				}
-				else {
+				if ((ceil_x <= right) && (floor_y <= bottom) &&
+					(ceil_x >= left) && (floor_y >= top)) {
+					p2 = *(source_bits + (int32)ceil_x +
+						(int32)floor_y * source_bpr);
+				} else
 					p2 = background.word;
-				}
 
-				if ((	floor_x <= right) && (ceil_y <= bottom)
-						&& (floor_x>=left) && (ceil_y>=top)) {
-					p3 = *(source_bits + (int32)floor_x + (int32)ceil_y*source_bpr);
-				}
-				else {
+				if ((floor_x <= right) && (ceil_y <= bottom) &&
+					(floor_x >= left) && (ceil_y >= top)) {
+					p3 = *(source_bits + (int32)floor_x +
+						(int32)ceil_y * source_bpr);
+				} else
 					p3 = background.word;
-				}
 
-				if ((	ceil_x <= right) && (ceil_y <= bottom)
-						&& (ceil_x>=left) && (ceil_y>=top)) {
-					p4 = *(source_bits + (int32)ceil_x + (int32)ceil_y*source_bpr);
-				}
-				else {
+				if ((ceil_x <= right) && (ceil_y <= bottom) &&
+					(ceil_x >= left) && (ceil_y >= top)) {
+					p4 = *(source_bits + (int32)ceil_x +
+						(int32)ceil_y * source_bpr);
+				} else
 					p4 = background.word;
-				}
 
-				*target_bits++ = bilinear_interpolation(p1,p2,p3,p4,u,v);
+				*target_bits++ = bilinear_interpolation(p1, p2, p3, p4, u, v);
 				x_times_sin += sin_angle;
 				x_times_cos += cos_angle;
 			}
 			y_times_sin += sin_angle;
 			y_times_cos += cos_angle;
-			if ((((int32)y % 20) == 0) && (status_bar != NULL) && (status_bar_window != NULL)) {
+			if ((((int32)y % 20) == 0) && (status_bar != NULL) &&
+				(status_bar_window != NULL)) {
 				status_bar_window->Lock();
-				status_bar->Update(100.0/(float)height*20);
+				status_bar->Update(100.0 / (float)height * 20);
 				status_bar_window->Unlock();
 			}
 		}
-	}
-	else {
+	} else {
 		// This should be done by first rotating the selection and then looking up what pixels
 		// of original image correspond to the pixels in the rotated selection. The only problem
 		// with this approach is if we want to clear the selection first so we must clear it before
 		// rotating the selection.
-//		selection->Recalculate();
-		for (int32 y=0;y<=height;y++) {
-			for (int32 x=0;x<=width;x++) {
-				if (selection->ContainsPoint(x,y))
-					*(target_bits + x + y*target_bpr) = background.word;
+		for (int32 y = 0;y <= height; y++) {
+			for (int32 x = 0; x <= width; x++) {
+				if (selection->ContainsPoint(x, y))
+					*(target_bits + x + y * target_bpr) = background.word;
 				else
-					*(target_bits + x + y*target_bpr) = *(source_bits + x + y*source_bpr);
+					*(target_bits + x + y * target_bpr) =
+						*(source_bits + x + y * source_bpr);
 			}
 		}
 
-
 		// We must make a copy of the selection in order to be able to rotate it
-//		Selection *new_selection = new Selection(selection);
-//		new_selection->RotateTo(new_settings->origo,new_settings->angle);
-//		new_selection->Recalculate();
 		selection->Recalculate();
 
 		BRect selection_bounds = selection->GetBoundingRect();
-		selection_bounds.PrintToStream();
 		int32 sel_top = (int32)selection_bounds.top;
 		int32 sel_bottom = (int32)selection_bounds.bottom;
 		int32 sel_left = (int32)selection_bounds.left;
 		int32 sel_right = (int32)selection_bounds.right;
-		y_times_sin = (sel_top-center_y)*sin_angle;
-		y_times_cos = (sel_top-center_y)*cos_angle;
-		for (float y=sel_top;y<=sel_bottom;y++) {
-			float x_times_sin = (sel_left-center_x)*sin_angle;
-			float x_times_cos = (sel_left-center_x)*cos_angle;
-			for (float x=sel_left;x<=sel_right;x++) {
+		y_times_sin = (sel_top - center_y) * sin_angle;
+		y_times_cos = (sel_top - center_y) * cos_angle;
+		for (float y = sel_top; y <= sel_bottom; y++) {
+			float x_times_sin = (sel_left - center_x) * sin_angle;
+			float x_times_cos = (sel_left - center_x) * cos_angle;
+			for (float x = sel_left; x <= sel_right; x++) {
 				if (selection->ContainsPoint(int32(x), int32(y))) {
 					// rotate here around the origin
 					source_x = x_times_cos - y_times_sin;
@@ -384,43 +391,47 @@ BBitmap* RotationManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap 
 					float u = source_x - floor_x;
 					float v = source_y - floor_y;
 					// Then add the weighted sums of the four pixels.
-					if ((	floor_x <= right) && (floor_y <= bottom)
-							&& (floor_x>=left) && (floor_y>=top) ) {
-						p1 = *(source_bits + (int32)floor_x + (int32)floor_y*source_bpr);
-					}
-					else {
+					if ((floor_x <= right) && (floor_y <= bottom) &&
+						(floor_x >= left) && (floor_y >= top)) {
+						p1 = src_over_fixed(
+							*(target_bits + (int32)x + (int32)y * target_bpr),
+							*(source_bits + (int32)floor_x +
+							(int32)floor_y * source_bpr));
+					} else
 						p1 = background.word;
-					}
 
 					// second
-					if ((	ceil_x <= right) && (floor_y <= bottom)
-							&& (ceil_x>=left) && (floor_y>=top) ) {
-						p2 = *(source_bits + (int32)ceil_x + (int32)floor_y*source_bpr);
-					}
-					else {
+					if ((ceil_x <= right) && (floor_y <= bottom) &&
+						(ceil_x >= left) && (floor_y >= top)) {
+						p2 = src_over_fixed(
+							*(target_bits + (int32)x + (int32)y * target_bpr),
+							*(source_bits + (int32)ceil_x +
+							(int32)ceil_y * source_bpr));
+					} else
 						p2 = background.word;
-					}
 
 					// third
-					if ((	floor_x <= right) && (ceil_y <= bottom)
-							&& (floor_x>=left) && (ceil_y>=top) ) {
-						p3 = *(source_bits + (int32)floor_x + (int32)ceil_y*source_bpr);
-					}
-					else {
+					if ((floor_x <= right) && (ceil_y <= bottom) &&
+						(floor_x >= left) && (ceil_y >= top)) {
+						p3 = src_over_fixed(
+							*(target_bits + (int32)x + (int32)y * target_bpr),
+							*(source_bits + (int32)floor_x +
+							(int32)ceil_y * source_bpr));
+					} else
 						p3 = background.word;
-					}
 
 					// fourth
-					if ((	ceil_x <= right) && (ceil_y <= bottom)
-							&& (ceil_x>=left) && (ceil_y>=top) ) {
-						p4 = *(source_bits + (int32)ceil_x + (int32)ceil_y*source_bpr);
-					}
-					else {
+					if ((ceil_x <= right) && (ceil_y <= bottom) &&
+						(ceil_x >= left) && (ceil_y >= top) ) {
+						p4 = src_over_fixed(
+							*(target_bits + (int32)x + (int32)y * target_bpr),
+							*(source_bits + (int32)ceil_x +
+							(int32)ceil_y * source_bpr));
+					} else
 						p4 = background.word;
-					}
 
-					*(target_bits + (int32)x + (int32)y*target_bpr) = bilinear_interpolation(p1,p2,p3,p4,u,v);
-
+					*(target_bits + (int32)x + (int32)y * target_bpr) =
+						bilinear_interpolation(p1, p2, p3, p4, u, v);
 				}
 				x_times_sin += sin_angle;
 				x_times_cos += cos_angle;
@@ -429,8 +440,9 @@ BBitmap* RotationManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap 
 			y_times_cos += cos_angle;
 			if ((status_bar != NULL) && (status_bar->Window() != NULL)) {
 				BMessage *a_message = new BMessage(B_UPDATE_STATUS_BAR);
-				a_message->AddFloat("delta",100.0/(float)(sel_bottom-sel_top));
-				status_bar->Window()->PostMessage(a_message,status_bar);
+				a_message->AddFloat("delta", 100.0 /
+					(float)(sel_bottom - sel_top));
+				status_bar->Window()->PostMessage(a_message, status_bar);
 				delete a_message;
 			}
 		}
@@ -440,7 +452,9 @@ BBitmap* RotationManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap 
 }
 
 
-int32 RotationManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRegion *updated_region)
+int32
+RotationManipulator::PreviewBitmap(Selection* selection, bool full_quality,
+	BRegion* updated_region)
 {
 	// First decide the resolution of the bitmap
 	if ((previous_angle == settings->angle) && (full_quality == FALSE)) {
@@ -449,41 +463,32 @@ int32 RotationManipulator::PreviewBitmap(Selection *selection,bool full_quality,
 			if (previous_origo != settings->origo) {
 				previous_origo = settings->origo;
 				return DRAW_ONLY_GUI;
-			}
-			else
+			} else
 				return 0;
-		}
-		else
+		} else
 			last_calculated_resolution = last_calculated_resolution / 2;
-	}
-	else if (full_quality == TRUE) {
+	} else if (full_quality == TRUE) {
 		last_calculated_resolution = 1;
-	}
-	else
+	} else
 		last_calculated_resolution = lowest_available_quality;
 
-
-	union {
-		uint8	bytes[4];
-		uint32	word;
-	} background;
+	union color_conversion background;
 	// Transparent background.
 	background.bytes[0] = 0xFF;
 	background.bytes[1] = 0xFF;
 	background.bytes[2] = 0xFF;
 	background.bytes[3] = 0x00;
 
-
 	// Then calculate the preview
 	BPoint center = settings->origo;
 	float the_angle = settings->angle;
-	float sin_angle = sin(-the_angle/360*2*PI);
-	float cos_angle = cos(-the_angle/360*2*PI);
+	float sin_angle = sin(-the_angle / 360 * 2 * PI);
+	float cos_angle = cos(-the_angle / 360 * 2 * PI);
 
 	int32 *target_bits = (int32*)preview_bitmap->Bits();
 	int32 *source_bits = (int32*)copy_of_the_preview_bitmap->Bits();
-	int32 source_bpr = copy_of_the_preview_bitmap->BytesPerRow()/4;
-	int32 target_bpr = preview_bitmap->BytesPerRow()/4;
+	int32 source_bpr = copy_of_the_preview_bitmap->BytesPerRow() / 4;
+	int32 target_bpr = preview_bitmap->BytesPerRow() / 4;
 
 	// copy the points according to angle
 	float height = preview_bitmap->Bounds().Height();
@@ -494,14 +499,14 @@ int32 RotationManipulator::PreviewBitmap(Selection *selection,bool full_quality,
 	float bottom = copy_of_the_preview_bitmap->Bounds().bottom;
 	float center_x = center.x;
 	float center_y = center.y;
-	float source_x,source_y;
-	float y_times_sin = (-center_y)*sin_angle;
-	float y_times_cos = (-center_y)*cos_angle;
+	float source_x, source_y;
+	float y_times_sin = (-center_y) * sin_angle;
+	float y_times_cos = (-center_y) * cos_angle;
 	if (selection->IsEmpty()) {
-		for (int32 y=0;y<=height;y += last_calculated_resolution) {
-			float x_times_sin = (-center_x)*sin_angle;
-			float x_times_cos = (-center_x)*cos_angle;
-			for (int32 x=0;x<=width;x += last_calculated_resolution) {
+		for (int32 y = 0; y <= height; y += last_calculated_resolution) {
+			float x_times_sin = (-center_x) * sin_angle;
+			float x_times_cos = (-center_x) * cos_angle;
+			for (int32 x = 0; x <= width; x += last_calculated_resolution) {
 				// rotete here around the origin
 				source_x = x_times_cos - y_times_sin;
 				source_y = x_times_sin + y_times_cos;
@@ -510,50 +515,60 @@ int32 RotationManipulator::PreviewBitmap(Selection *selection,bool full_quality,
 				source_y += center_y;
 				if ((source_x <= right) && (source_y <= bottom)
 					&& (source_x >= left) && (source_y >= top)) {
-						*(target_bits + x + y*target_bpr) =
-							*(source_bits + (int32)source_x + (int32)source_y*source_bpr);
+						*(target_bits + x + y * target_bpr) =
+							*(source_bits + (int32)source_x +
+							(int32)source_y * source_bpr);
 				}
 				else
-					*(target_bits + x + y*target_bpr) = background.word;	// Transparent.
+					*(target_bits + x + y * target_bpr) = background.word;
 
-				x_times_sin += last_calculated_resolution*sin_angle;
-				x_times_cos += last_calculated_resolution*cos_angle;
+				x_times_sin += last_calculated_resolution * sin_angle;
+				x_times_cos += last_calculated_resolution * cos_angle;
 			}
-			y_times_sin += last_calculated_resolution*sin_angle;
-			y_times_cos += last_calculated_resolution*cos_angle;
+			y_times_sin += last_calculated_resolution * sin_angle;
+			y_times_cos += last_calculated_resolution * cos_angle;
 		}
-	}
-	else {
+	} else {
 		// Rotate the selection also
-		selection->RotateTo(center,the_angle);
-		for (int32 y=0;y<=height;y += last_calculated_resolution) {
-			float x_times_sin = (-center_x)*sin_angle;
-			float x_times_cos = (-center_x)*cos_angle;
-			for (int32 x=0;x<=width;x += last_calculated_resolution) {
+		selection->RotateTo(center, the_angle);
+		for (int32 y = 0; y <= height; y += last_calculated_resolution) {
+			float x_times_sin = (-center_x) * sin_angle;
+			float x_times_cos = (-center_x) * cos_angle;
+			for (int32 x = 0; x <= width; x += last_calculated_resolution) {
 				// rotete here around the origin
 				source_x = x_times_cos - y_times_sin;
 				source_y = x_times_sin + y_times_cos;
 				// translate back to correct position
 				source_x += center_x;
 				source_y += center_y;
-				if ((source_x <= right) && (source_y <= bottom)
-					&& (source_x >= left) && (source_y >= top)
-					&& selection->ContainsPoint(int32(source_x), int32(source_y))) {
-						*(target_bits + x + y*target_bpr) =
-							*(source_bits + (int32)source_x + (int32)source_y*source_bpr);
-				}
-				else if (selection->ContainsPoint(BPoint(source_x,source_y)))
-					*(target_bits + x + y*target_bpr) = background.word;	// Transparent.
+				if ((source_x <= right) && (source_y <= bottom) &&
+					(source_x >= left) && (source_y >= top)
+					&& selection->ContainsPoint(int32(source_x),
+						int32(source_y))) {
+						if (selection->ContainsPoint(x, y))
+							*(target_bits + x + y * target_bpr) =
+								src_over_fixed(background.word,
+									*(source_bits + (int32)source_x +
+									(int32)source_y * source_bpr));
+						else
+							*(target_bits + x + y * target_bpr) =
+								src_over_fixed(
+									*(source_bits + (int32)x + (int32)y * source_bpr),
+									*(source_bits + (int32)source_x +
+									(int32)source_y * source_bpr));
+				} else if (selection->ContainsPoint(BPoint(source_x, source_y)))
+					*(target_bits + x + y * target_bpr) = background.word;	// Transparent.
 				else if (selection->ContainsPoint(x,y))
-					*(target_bits + x + y*target_bpr) = background.word;
-				else
-					*(target_bits + x + y*target_bpr) = *(source_bits + (int32)x + (int32)y*source_bpr);
+					*(target_bits + x + y * target_bpr) = background.word;
+				else // outside selection
+					*(target_bits + x + y * target_bpr) =
+						*(source_bits + (int32)x + (int32)y * source_bpr);
 
-				x_times_sin += last_calculated_resolution*sin_angle;
-				x_times_cos += last_calculated_resolution*cos_angle;
+				x_times_sin += last_calculated_resolution * sin_angle;
+				x_times_cos += last_calculated_resolution * cos_angle;
 			}
-			y_times_sin += last_calculated_resolution*sin_angle;
-			y_times_cos += last_calculated_resolution*cos_angle;
+			y_times_sin += last_calculated_resolution * sin_angle;
+			y_times_cos += last_calculated_resolution * cos_angle;
 		}
 	}
 
@@ -563,19 +578,20 @@ int32 RotationManipulator::PreviewBitmap(Selection *selection,bool full_quality,
 }
 
 
-void RotationManipulator::Reset(Selection *selection)
+void
+RotationManipulator::Reset(Selection* selection)
 {
-	selection->RotateTo(settings->origo,0);
+	selection->RotateTo(settings->origo, 0);
 	settings->angle = 0;
 	previous_angle = 0;
 
 	if (copy_of_the_preview_bitmap != NULL) {
 		// memcpy seems to be about 10-15% faster that copying with loop.
-		uint32 *source = (uint32*)copy_of_the_preview_bitmap->Bits();
-		uint32 *target = (uint32*)preview_bitmap->Bits();
+		uint32* source = (uint32*)copy_of_the_preview_bitmap->Bits();
+		uint32* target = (uint32*)preview_bitmap->Bits();
 		uint32 bits_length = preview_bitmap->BitsLength();
 
-		memcpy(target,source,bits_length);
+		memcpy(target, source, bits_length);
 	}
 }
 
@@ -583,9 +599,6 @@ void RotationManipulator::Reset(Selection *selection)
 BView*
 RotationManipulator::MakeConfigurationView(const BMessenger& target)
 {
-	//if (config_view)
-	//	return config_view;
-
 	config_view =
 		new RotationManipulatorConfigurationView(this, target);
 	config_view->SetAngle(settings->angle);
@@ -620,9 +633,9 @@ RotationManipulator::ReturnName()
 
 RotationManipulatorConfigurationView::RotationManipulatorConfigurationView(
 		RotationManipulator* manipulator, const BMessenger& target)
-	: WindowGUIManipulatorView()
-	, fTarget(target)
-	, fManipulator(manipulator)
+	: WindowGUIManipulatorView(),
+	fTarget(target),
+	fManipulator(manipulator)
 {
 	fTextControl = new BTextControl("rotation", B_TRANSLATE("Angle:"), "9999.9˚",
 		new BMessage(HS_MANIPULATOR_ADJUSTING_FINISHED));

--- a/artpaint/viewmanipulators/TranslationManipulator.cpp
+++ b/artpaint/viewmanipulators/TranslationManipulator.cpp
@@ -4,12 +4,14 @@
  *
  * Authors:
  * 		Heikki Suhonen <heikki.suhonen@gmail.com>
+ *		Dale Cieslak <dcieslak@yahoo.com>
  *
  */
-
+#include "BitmapUtilities.h"
 #include "ImageView.h"
 #include "MessageConstants.h"
 #include "NumberControl.h"
+#include "PixelOperations.h"
 #include "Selection.h"
 #include "TranslationManipulator.h"
 
@@ -22,7 +24,6 @@
 
 
 #include <new>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -34,9 +35,9 @@
 using ArtPaint::Interface::NumberControl;
 
 
-TranslationManipulator::TranslationManipulator(BBitmap *bm)
-	:	WindowGUIManipulator()
-	, copy_of_the_preview_bitmap(NULL)
+TranslationManipulator::TranslationManipulator(BBitmap* bm)
+	: WindowGUIManipulator(),
+	copy_of_the_preview_bitmap(NULL)
 {
 	preview_bitmap = bm;
 	if (preview_bitmap != NULL)
@@ -60,33 +61,33 @@ TranslationManipulator::~TranslationManipulator()
 		config_view->RemoveSelf();
 		delete config_view;
 	}
-
 }
 
 
-void TranslationManipulator::MouseDown(BPoint point,uint32,BView*,bool first)
+void
+TranslationManipulator::MouseDown(BPoint point, uint32, BView*, bool first)
 {
 	if (first)
 		previous_point = point;
 	else {
-//		previous_x_translation = settings->x_translation;
-//		previous_y_translation = settings->y_translation;
-
 		settings->x_translation += point.x - previous_point.x;
 		settings->y_translation += point.y - previous_point.y;
 
 		previous_point = point;
 
 		if (config_view != NULL)
-			config_view->SetValues(settings->x_translation,settings->y_translation);
+			config_view->SetValues(settings->x_translation,
+				settings->y_translation);
 	}
 }
 
 
-BBitmap* TranslationManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap*
+TranslationManipulator::ManipulateBitmap(ManipulatorSettings* set,
+	BBitmap* original, Selection* selection, BStatusBar* status_bar)
 {
-//	printf("TranslationManipulator::ManipulateBitmap\n");
-	TranslationManipulatorSettings *new_settings = cast_as(set,TranslationManipulatorSettings);
+	TranslationManipulatorSettings *new_settings = cast_as(set,
+		TranslationManipulatorSettings);
 
 	if ((status_bar != NULL) && (status_bar->Window() != NULL)) {
 		if (status_bar->Window()->LockWithTimeout(0) == B_OK) {
@@ -95,86 +96,80 @@ BBitmap* TranslationManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitm
 		}
 	}
 
-	if (new_settings == NULL) {
+	if (new_settings == NULL)
 		return NULL;
-	}
-	if (original == NULL) {
-		return NULL;
-	}
-	if ((new_settings->x_translation == 0) && (new_settings->y_translation == 0)) {
-		return NULL;
-	}
 
-	BBitmap *new_bitmap;
+	if (original == NULL)
+		return NULL;
+
+	if ((new_settings->x_translation == 0) &&
+		(new_settings->y_translation == 0))
+		return NULL;
+
+	BBitmap* new_bitmap;
 	if (original != preview_bitmap) {
 		original->Lock();
 		BRect bitmap_frame = original->Bounds();
-		new_bitmap = new BBitmap(bitmap_frame,B_RGB_32_BIT);
+		new_bitmap = new BBitmap(bitmap_frame, B_RGB_32_BIT);
 		original->Unlock();
 		if (new_bitmap->IsValid() == FALSE) {
 			throw std::bad_alloc();
 		}
-	}
-	else {
+	} else {
 		new_bitmap = original;
 		original = copy_of_the_preview_bitmap;
 	}
 
-	union {
-		uint8	bytes[4];
-		uint32	word;
-	} background;
+	union color_conversion background;
 	// Transparent background.
 	background.bytes[0] = 0xFF;
 	background.bytes[1] = 0xFF;
 	background.bytes[2] = 0xFF;
 	background.bytes[3] = 0x00;
 
-
 	// This function assumes that the both bitmaps are of same size.
 	uint32 *target_bits = (uint32*)new_bitmap->Bits();
 	uint32 *source_bits = (uint32*)original->Bits();
-	uint32 target_bpr = new_bitmap->BytesPerRow()/4;
-	uint32 source_bpr = original->BytesPerRow()/4;
-//	printf("test5\n");
-	int32 width = (int32)min_c(new_bitmap->Bounds().Width()+1,original->Bounds().Width()+1);
-	int32 height = (int32)min_c(new_bitmap->Bounds().Height()+1,original->Bounds().Height()+1);
-//	printf("%d %d\n",width,height);
+	uint32 target_bpr = new_bitmap->BytesPerRow() / 4;
+	uint32 source_bpr = original->BytesPerRow() / 4;
+	int32 width = (int32)min_c(new_bitmap->Bounds().Width() + 1,
+		original->Bounds().Width() + 1);
+	int32 height = (int32)min_c(new_bitmap->Bounds().Height() + 1,
+		original->Bounds().Height() + 1);
 
 	// We have to copy translations so that we do translation for all pixels
 	// with the same values
 	int32 x_translation_local = ((int32)new_settings->x_translation);
 	int32 y_translation_local = ((int32)new_settings->y_translation);
-//	printf("%d %d\n",x_translation_local,y_translation_local);
 	if (selection->IsEmpty()) {
-//		printf("Selection is empty\n");
 		// First clear the target bitmap. Here the clearing of the whole bitmap is not usually necessary.
 		// Actually this loop combined with the next should only set each pixel in the bitmap exactly once.
-		for (int32 y=0;y<height;y++) {
-			for (int32 x=0;x<width;x++) {
-				*(target_bits + x + y*target_bpr) = background.word;
+		for (int32 y = 0; y < height; y++) {
+			for (int32 x = 0; x < width; x++) {
+				*(target_bits + x + y * target_bpr) = background.word;
 			}
 		}
-//		printf("Cleared the target\n");
 		// Copy only the points that are within the intersection of
 		// original_bitmap->Bounds() and original_bitmap->Bounds().OffsetBy(x_translation,y_translation)
-		int32 target_x_offset = max_c(0,x_translation_local);
-		int32 target_y_offset = max_c(0,y_translation_local);
-		int32 source_x_offset = max_c(0,-x_translation_local);
-		int32 source_y_offset = max_c(0,-y_translation_local);
+		int32 target_x_offset = max_c(0, x_translation_local);
+		int32 target_y_offset = max_c(0, y_translation_local);
+		int32 source_x_offset = max_c(0, -x_translation_local);
+		int32 source_y_offset = max_c(0, -y_translation_local);
 
-		for (int32 y = 0;y<height - abs(y_translation_local);y++) {
-			for (int32 x = 0;x<width - abs(x_translation_local);x++) {
-				*(target_bits + x+target_x_offset + (y + target_y_offset)*target_bpr)
-				 = *(source_bits + x+source_x_offset + (y + source_y_offset)*source_bpr);
+		for (int32 y = 0; y < height - abs(y_translation_local); y++) {
+			for (int32 x = 0; x < width - abs(x_translation_local); x++) {
+				*(target_bits + x + target_x_offset +
+				(y + target_y_offset) * target_bpr) =
+					*(source_bits + x + source_x_offset +
+					(y + source_y_offset) * source_bpr);
 			}
 		}
-	}
-	else {
+	} else {
 		// First reset the picture
-		for (int32 y=0;y<height;y++) {
-			for (int32 x=0;x<width;x++) {
-				*(target_bits + x + y*target_bpr) = *(source_bits + x + y*source_bpr);
+		for (int32 y = 0; y < height; y++) {
+			for (int32 x = 0; x < width; x++) {
+				*(target_bits + x + y * target_bpr) =
+					*(source_bits + x + y * source_bpr);
 			}
 		}
 
@@ -184,185 +179,207 @@ BBitmap* TranslationManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitm
 		int32 right = (int32)selection_bounds.right;
 		int32 top = (int32)selection_bounds.top;
 		int32 bottom = (int32)selection_bounds.bottom;
-		for (int32 y=top;y<=bottom;y++) {
-			for (int32 x=left;x<=right;x++) {
-				if (selection->ContainsPoint(x,y))
-					*(target_bits + x + y*target_bpr) = background.word;
+		for (int32 y = top; y <= bottom; y++) {
+			for (int32 x = left; x <= right; x++) {
+				if (selection->ContainsPoint(x, y))
+					*(target_bits + x + y * target_bpr) = background.word;
 			}
 		}
 
-
 		selection_bounds = selection->GetBoundingRect();
-		selection_bounds.OffsetBy(settings->x_translation,settings->y_translation);
-		selection_bounds = selection_bounds & original->Bounds() & new_bitmap->Bounds();
+		selection_bounds.OffsetBy(settings->x_translation,
+			settings->y_translation);
+		selection_bounds = selection_bounds & original->Bounds() &
+			new_bitmap->Bounds();
 		left = (int32)selection_bounds.left;
 		right = (int32)selection_bounds.right;
 		top = (int32)selection_bounds.top;
 		bottom = (int32)selection_bounds.bottom;
-		for (int32 y=top;y<=bottom;y++) {
-			for (int32 x=left;x<=right;x++) {
+		for (int32 y = top; y <= bottom; y++) {
+			for (int32 x = left; x <= right; x++) {
 				int32 new_x = (int32)(x - new_settings->x_translation);
 				int32 new_y = (int32)(y - new_settings->y_translation);
-				if (selection->ContainsPoint(new_x,new_y))
-					*(target_bits + x + y*target_bpr) = *(source_bits + new_x + new_y*source_bpr);
+				if (selection->ContainsPoint(new_x, new_y))
+					*(target_bits + x + y * target_bpr) = src_over_fixed(
+						*(target_bits + x + y * target_bpr),
+						*(source_bits + new_x + new_y * source_bpr));
 			}
 		}
-//		printf("Did the translation\n");
 	}
 
 	return new_bitmap;
 }
 
 
-int32 TranslationManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRegion *updated_region)
+int32
+TranslationManipulator::PreviewBitmap(Selection* selection, bool full_quality,
+	BRegion* updated_region)
 {
-	if ((preview_bitmap == NULL) || (copy_of_the_preview_bitmap == NULL))
+	if (preview_bitmap == NULL || copy_of_the_preview_bitmap == NULL)
 		return 0;
 	// First decide the resolution of the bitmap
-	if ((previous_x_translation == settings->x_translation) && (previous_y_translation == settings->y_translation) && (full_quality == FALSE)) {
+	if ((previous_x_translation == settings->x_translation) &&
+		(previous_y_translation == settings->y_translation) &&
+		(full_quality == FALSE)) {
 		if (last_calculated_resolution <= highest_available_quality) {
 			last_calculated_resolution = 0;
 			if (full_quality == TRUE) {
 				updated_region->Set(preview_bitmap->Bounds());
 				return 1;
-			}
-			else
+			} else
 				return 0;
-		}
-		else {
+		} else {
 			if (full_quality == FALSE)
 				last_calculated_resolution = last_calculated_resolution / 2;
 			else
-				last_calculated_resolution = min_c(1,last_calculated_resolution/2);
+				last_calculated_resolution = min_c(1, last_calculated_resolution/2);
 		}
-	}
-	else if (full_quality == TRUE)
+	} else if (full_quality == TRUE)
 		last_calculated_resolution = 1;
 	else
 		last_calculated_resolution = lowest_available_quality;
 
 	if (last_calculated_resolution > 0) {
-		union {
-			uint8	bytes[4];
-			uint32	word;
-		} background;
+		union color_conversion background;
 		// Transparent background.
 		background.bytes[0] = 0xFF;
 		background.bytes[1] = 0xFF;
 		background.bytes[2] = 0xFF;
 		background.bytes[3] = 0x00;
 
-
 		// This function assumes that the both bitmaps are of same size.
 		uint32 *target_bits = (uint32*)preview_bitmap->Bits();
 		uint32 *source_bits = (uint32*)copy_of_the_preview_bitmap->Bits();
-		uint32 target_bpr = preview_bitmap->BytesPerRow()/4;
-		uint32 source_bpr = copy_of_the_preview_bitmap->BytesPerRow()/4;
+		uint32 target_bpr = preview_bitmap->BytesPerRow() / 4;
+		uint32 source_bpr = copy_of_the_preview_bitmap->BytesPerRow() / 4;
 
-		int32 width = (int32)min_c(preview_bitmap->Bounds().Width()+1,copy_of_the_preview_bitmap->Bounds().Width()+1);
-		int32 height = (int32)min_c(preview_bitmap->Bounds().Height()+1,copy_of_the_preview_bitmap->Bounds().Height()+1);
+		int32 width = (int32)min_c(preview_bitmap->Bounds().Width() + 1,
+			copy_of_the_preview_bitmap->Bounds().Width() + 1);
+		int32 height = (int32)min_c(preview_bitmap->Bounds().Height() + 1,
+			copy_of_the_preview_bitmap->Bounds().Height() + 1);
 
 		// We have to copy translations so that we do translation for all pixels
 		// with the same values
-		int32 x_translation_local = ((int32)settings->x_translation)/last_calculated_resolution*last_calculated_resolution;
-		int32 y_translation_local = ((int32)settings->y_translation)/last_calculated_resolution*last_calculated_resolution;
+		int32 x_translation_local = ((int32)settings->x_translation) /
+			last_calculated_resolution * last_calculated_resolution;
+		int32 y_translation_local = ((int32)settings->y_translation) /
+			last_calculated_resolution * last_calculated_resolution;
 		if (selection->IsEmpty()) {
 			// First clear the target bitmap.
 			BRegion to_be_cleared;
 			to_be_cleared.Set(uncleared_rect);
 //			uncleared_rect.PrintToStream();
-			uncleared_rect.left = max_c(0,x_translation_local);
-			uncleared_rect.top = max_c(0,y_translation_local);
-			uncleared_rect.right = min_c(width-1,width-1+x_translation_local);
-			uncleared_rect.bottom = min_c(height-1,height-1+y_translation_local);
+			uncleared_rect.left = max_c(0, x_translation_local);
+			uncleared_rect.top = max_c(0, y_translation_local);
+			uncleared_rect.right = min_c(width - 1,
+				width - 1 + x_translation_local);
+			uncleared_rect.bottom = min_c(height - 1,
+				height - 1 + y_translation_local);
 			to_be_cleared.Exclude(uncleared_rect);
-			for (int32 i=0;i<to_be_cleared.CountRects();i++) {
+			for (int32 i = 0; i < to_be_cleared.CountRects(); i++) {
 				BRect rect = to_be_cleared.RectAt(i);
-				int32 left = (int32)(floor(rect.left / last_calculated_resolution) * last_calculated_resolution);
-				int32 top = (int32)(floor(rect.top / last_calculated_resolution) * last_calculated_resolution);
-				int32 right = (int32)(ceil(rect.right / last_calculated_resolution) * last_calculated_resolution);
-				int32 bottom = (int32)(ceil(rect.bottom / last_calculated_resolution) * last_calculated_resolution);
-		//		printf("left %d, top %d, res: %d\n",left,top,last_calculated_resolution);
-				for (int32 y=top;y<=bottom;y += last_calculated_resolution) {
-					for (int32 x=left;x<=right;x += last_calculated_resolution) {
-						*(target_bits + x + y*target_bpr) = background.word;
+				int32 left = (int32)(floor(rect.left /
+					last_calculated_resolution) * last_calculated_resolution);
+				int32 top = (int32)(floor(rect.top /
+					last_calculated_resolution) * last_calculated_resolution);
+				int32 right = (int32)(ceil(rect.right /
+					last_calculated_resolution) * last_calculated_resolution);
+				int32 bottom = (int32)(ceil(rect.bottom /
+					last_calculated_resolution) * last_calculated_resolution);
+				for (int32 y = top; y <= bottom;y += last_calculated_resolution) {
+					for (int32 x = left; x <= right;x += last_calculated_resolution) {
+						*(target_bits + x + y * target_bpr) = background.word;
 					}
 				}
 			}
 			// Copy only the points that are within the intersection of
 			// original_bitmap->Bounds() and original_bitmap->Bounds().OffsetBy(x_translation,y_translation)
-			int32 target_x_offset = max_c(0,x_translation_local);
-			int32 target_y_offset = max_c(0,y_translation_local);
-			int32 source_x_offset = max_c(0,-x_translation_local);
-			int32 source_y_offset = max_c(0,-y_translation_local);
+			int32 target_x_offset = max_c(0, x_translation_local);
+			int32 target_y_offset = max_c(0, y_translation_local);
+			int32 source_x_offset = max_c(0, -x_translation_local);
+			int32 source_y_offset = max_c(0, -y_translation_local);
 
-			for (int32 y = 0;y<height - abs(y_translation_local);y += last_calculated_resolution) {
-				for (int32 x = 0;x<width - abs(x_translation_local);x += last_calculated_resolution) {
-					*(target_bits + x+target_x_offset + (y + target_y_offset)*target_bpr)
-					 = *(source_bits + x+source_x_offset + (y + source_y_offset)*source_bpr);
+			for (int32 y = 0; y < height - abs(y_translation_local);
+				y += last_calculated_resolution) {
+				for (int32 x = 0;x < width - abs(x_translation_local);
+					x += last_calculated_resolution) {
+					*(target_bits + x + target_x_offset +
+					(y + target_y_offset) * target_bpr) =
+						*(source_bits + x + source_x_offset +
+						(y + source_y_offset) * source_bpr);
 				}
 			}
 
 			updated_region->Set(uncleared_rect);
 			updated_region->Include(&to_be_cleared);
-//			updated_region->Set(preview_bitmap->Bounds());
 		}
 		else {
-			selection->Translate(x_translation_local-previous_x_translation,y_translation_local-previous_y_translation);
+			selection->Translate(x_translation_local - previous_x_translation,
+				y_translation_local - previous_y_translation);
 
 			// First reset the picture
 			BRegion to_be_cleared;
 			to_be_cleared.Set(uncleared_rect);
 			uncleared_rect = selection->GetBoundingRect();
-			uncleared_rect.OffsetBy(x_translation_local,y_translation_local);
-			uncleared_rect.InsetBy(-1,-1);
+			uncleared_rect.OffsetBy(x_translation_local, y_translation_local);
+			uncleared_rect.InsetBy(-1, -1);
 			uncleared_rect = uncleared_rect & preview_bitmap->Bounds();
-			for (int32 i=0;i<to_be_cleared.CountRects();i++) {
+			for (int32 i = 0; i < to_be_cleared.CountRects(); i++) {
 				BRect rect = to_be_cleared.RectAt(i);
-				int32 left = (int32)(floor(rect.left / last_calculated_resolution) * last_calculated_resolution);
-				int32 top = (int32)(floor(rect.top / last_calculated_resolution) * last_calculated_resolution);
-				int32 right = (int32)(floor(rect.right / last_calculated_resolution) * last_calculated_resolution);
-				int32 bottom = (int32)(floor(rect.bottom / last_calculated_resolution) * last_calculated_resolution);
+				int32 left = (int32)(floor(rect.left /
+					last_calculated_resolution) * last_calculated_resolution);
+				int32 top = (int32)(floor(rect.top /
+					last_calculated_resolution) * last_calculated_resolution);
+				int32 right = (int32)(floor(rect.right /
+					last_calculated_resolution) * last_calculated_resolution);
+				int32 bottom = (int32)(floor(rect.bottom /
+					last_calculated_resolution) * last_calculated_resolution);
 
-				for (int32 y=top;y<=bottom;y += last_calculated_resolution) {
-					for (int32 x=left;x<=right;x += last_calculated_resolution) {
-						*(target_bits + x + y*target_bpr) = *(source_bits + x + y*source_bpr);
+				for (int32 y = top; y <= bottom;y += last_calculated_resolution) {
+					for (int32 x = left; x <= right;x += last_calculated_resolution) {
+						*(target_bits + x + y*target_bpr) =
+							*(source_bits + x + y * source_bpr);
 					}
 				}
 			}
 
 			// Then do the selection
 			BRect selection_bounds = selection->GetBoundingRect();
-			selection_bounds.left = ceil(selection_bounds.left / last_calculated_resolution)*last_calculated_resolution;
-			selection_bounds.top = ceil(selection_bounds.top / last_calculated_resolution)*last_calculated_resolution;
+			selection_bounds.left = ceil(selection_bounds.left /
+				last_calculated_resolution) * last_calculated_resolution;
+			selection_bounds.top = ceil(selection_bounds.top /
+				last_calculated_resolution) * last_calculated_resolution;
 			int32 left = (int32)selection_bounds.left;
 			int32 right = (int32)selection_bounds.right;
 			int32 top = (int32)selection_bounds.top;
 			int32 bottom = (int32)selection_bounds.bottom;
-			for (int32 y=top;y<=bottom;y += last_calculated_resolution) {
-				for (int32 x=left;x<=right;x += last_calculated_resolution) {
-					if (selection->ContainsPoint(x,y))
-						*(target_bits + x + y*target_bpr) = background.word;
+			for (int32 y = top; y <= bottom;y += last_calculated_resolution) {
+				for (int32 x = left; x <= right;x += last_calculated_resolution) {
+					if (selection->ContainsPoint(x, y))
+						*(target_bits + x + y * target_bpr) = background.word;
 				}
 			}
 
-
-
 			selection_bounds = selection->GetBoundingRect();
-			selection_bounds.OffsetBy(settings->x_translation,settings->y_translation);
+			selection_bounds.OffsetBy(settings->x_translation,
+				settings->y_translation);
 			selection_bounds = selection_bounds & preview_bitmap->Bounds();
-			selection_bounds.left = ceil(selection_bounds.left / last_calculated_resolution)*last_calculated_resolution;
-			selection_bounds.top = ceil(selection_bounds.top / last_calculated_resolution)*last_calculated_resolution;
+			selection_bounds.left = ceil(selection_bounds.left /
+				last_calculated_resolution) * last_calculated_resolution;
+			selection_bounds.top = ceil(selection_bounds.top /
+				last_calculated_resolution) * last_calculated_resolution;
 			left = (int32)selection_bounds.left;
 			right = (int32)selection_bounds.right;
 			top = (int32)selection_bounds.top;
 			bottom = (int32)selection_bounds.bottom;
-			for (int32 y=top;y<=bottom;y += last_calculated_resolution) {
-				for (int32 x=left;x<=right;x += last_calculated_resolution) {
+			for (int32 y = top; y <= bottom;y += last_calculated_resolution) {
+				for (int32 x = left;x <= right;x += last_calculated_resolution) {
 					int32 new_x = (int32)(x - settings->x_translation);
 					int32 new_y = (int32)(y - settings->y_translation);
-					if (selection->ContainsPoint(new_x,new_y))
-						*(target_bits + x + y*target_bpr) = *(source_bits + new_x + new_y*source_bpr);
+					if (selection->ContainsPoint(new_x, new_y))
+						*(target_bits + x + y * target_bpr) = src_over_fixed(
+							*(target_bits + x + y * target_bpr),
+							*(source_bits + new_x + new_y * source_bpr));
 				}
 			}
 
@@ -375,15 +392,19 @@ int32 TranslationManipulator::PreviewBitmap(Selection *selection,bool full_quali
 	return last_calculated_resolution;
 }
 
-ManipulatorSettings* TranslationManipulator::ReturnSettings()
+
+ManipulatorSettings*
+TranslationManipulator::ReturnSettings()
 {
 	return new TranslationManipulatorSettings(settings);
 }
 
 
-void TranslationManipulator::Reset(Selection *sel)
+void
+TranslationManipulator::Reset(Selection* sel)
 {
-	sel->Translate(int32(-settings->x_translation), int32(-settings->y_translation));
+	sel->Translate(int32(-settings->x_translation),
+		int32(-settings->y_translation));
 	settings->x_translation = 0;
 	settings->y_translation = 0;
 	previous_x_translation = 0;
@@ -391,18 +412,19 @@ void TranslationManipulator::Reset(Selection *sel)
 
 	if (preview_bitmap != NULL) {
 		// memcpy seems to be about 10-15% faster that copying with loop.
-		uint32 *source = (uint32*)copy_of_the_preview_bitmap->Bits();
-		uint32 *target = (uint32*)preview_bitmap->Bits();
+		uint32* source = (uint32*)copy_of_the_preview_bitmap->Bits();
+		uint32* target = (uint32*)preview_bitmap->Bits();
 		uint32 bits_length = preview_bitmap->BitsLength();
 
-		memcpy(target,source,bits_length);
+		memcpy(target, source, bits_length);
 
 		uncleared_rect = preview_bitmap->Bounds();
 	}
 }
 
 
-void TranslationManipulator::SetPreviewBitmap(BBitmap *bm)
+void
+TranslationManipulator::SetPreviewBitmap(BBitmap* bm)
 {
 	delete copy_of_the_preview_bitmap;
 	preview_bitmap = bm;
@@ -423,17 +445,15 @@ void TranslationManipulator::SetPreviewBitmap(BBitmap *bm)
 		while ((2*num_pixels/lowest_available_quality/lowest_available_quality) > speed)
 			lowest_available_quality *= 2;
 
-		highest_available_quality = max_c(lowest_available_quality/2,1);
+		highest_available_quality = max_c(lowest_available_quality / 2, 1);
 
 		uncleared_rect = preview_bitmap->Bounds();
-	}
-	else {
+	} else {
 		lowest_available_quality = 1;
 		highest_available_quality = 1;
 	}
 	last_calculated_resolution = lowest_available_quality;
 }
-
 
 
 BView*


### PR DESCRIPTION
Translation before this change; note how the transparent portion of the selection occludes the image:
![before01](https://user-images.githubusercontent.com/10878750/191416111-e7f19e5d-1b1e-4a25-8252-f5ef9c9128b1.png)
![before02](https://user-images.githubusercontent.com/10878750/191416125-db573808-70a2-46c4-a816-f60411795565.png)

Translation after this change; note how the transparent portion of the selection is respected:
![after01](https://user-images.githubusercontent.com/10878750/191416163-cc55fc39-8f45-4799-bc67-ef681652f0a0.png)
![after02](https://user-images.githubusercontent.com/10878750/191416194-d660d215-dc2e-4a75-b426-8409ae885a8c.png)

Rotation before this change; again the transparent portion of the selection is occluding the image:
![before01](https://user-images.githubusercontent.com/10878750/191416216-3e5fd9b0-6b50-4704-a377-5a0e99d0389b.png)
![before03](https://user-images.githubusercontent.com/10878750/191416250-23b7f729-20f3-47f4-b699-0400b674b2ba.png)

Rotation after this change; transparency of the selection is respected:
![after01](https://user-images.githubusercontent.com/10878750/191416283-3ebd8d4c-d9d0-47a3-8a7d-2ed558829cd5.png)
![after03](https://user-images.githubusercontent.com/10878750/191416308-c1f6d579-4887-419f-bc8d-9dc419df4538.png)

Also cleaned up the code style for TranslationManipulator and RotationManipulator a bit.

Fixes #120 

