### PR TITLE
Color Palette/Number controls: trimmed the fat

### DIFF
--- a/artpaint/controls/CMYColorControl.cpp
+++ b/artpaint/controls/CMYColorControl.cpp
@@ -29,7 +29,7 @@ CMYColorControl::CMYColorControl(rgb_color c)
 {
 	BGridLayout* mainLayout = (BGridLayout*)GetLayout();
 
-	BMessage *message = new BMessage(SLIDER_CHANGED);
+	BMessage* message = new BMessage(SLIDER5_CHANGED);
 	slider5 = new ColorFloatSlider("A",
  		"0", message, 0, 255, false);
  	slider5->Slider()->SetBarThickness(slider1->Slider()->BarThickness());
@@ -62,11 +62,33 @@ CMYColorControl::CMYColorControl(rgb_color c)
 }
 
 
+CMYColorControl::~CMYColorControl()
+{
+	slider5->RemoveSelf();
+
+	if (slider5 != NULL)
+		delete slider5;
+}
+
+
+void
+CMYColorControl::AttachedToWindow()
+{
+ 	slider5->SetTarget(this);
+
+ 	MultichannelColorControl::AttachedToWindow();
+}
+
+
 void
 CMYColorControl::MessageReceived(BMessage* message)
 {
- 	switch (message->what) {
- 		case SLIDER_CHANGED: {
+	switch (message->what) {
+ 		case SLIDER1_CHANGED:
+ 		case SLIDER2_CHANGED:
+ 		case SLIDER3_CHANGED:
+ 		case SLIDER4_CHANGED:
+ 		case SLIDER5_CHANGED: {
  			uint32 buttons;
  			BPoint point;
  			GetMouse(&point, &buttons);

--- a/artpaint/controls/CMYColorControl.h
+++ b/artpaint/controls/CMYColorControl.h
@@ -14,13 +14,18 @@
 #include "MultichannelColorControl.h"
 
 
+#define SLIDER5_CHANGED		's5Ch'
+
+
 using ArtPaint::Interface::ColorFloatSlider;
 
 
 class CMYColorControl : public MultichannelColorControl {
 public:
-		CMYColorControl(rgb_color c);
+					CMYColorControl(rgb_color c);
+					~CMYColorControl();
 
+		void		AttachedToWindow();
 		void		MessageReceived(BMessage* message);
 virtual	void		SetValue(rgb_color c);
 virtual	void		SetValue(float one, float two,

--- a/artpaint/controls/ColorFloatSlider.cpp
+++ b/artpaint/controls/ColorFloatSlider.cpp
@@ -47,11 +47,13 @@ ColorFloatSlider::ColorFloatSlider(const char* label, const char* text,
 {
 	_InitMessage();
 
+	BFont font;
+
 	fMult = pow(10, resolution);
 
 	fFormat.SetToFormat("%%0.%df", resolution);
 	fFloatControl = new (std::nothrow) FloatControl(label, text,
-		new BMessage(kNumberControlFinished), 6, minRange < 0);
+		new BMessage(kNumberControlFinished), 5, minRange < 0);
 	fSlider = new (std::nothrow) ColorSlider(NULL, NULL,
 		new BMessage(kSliderModificationFinished), (int32)minRange * fMult,
 		(int32)maxRange * fMult, B_HORIZONTAL, thumbStyle);
@@ -102,6 +104,11 @@ ColorFloatSlider::MessageReceived(BMessage* message)
 			BString value;
 			value.SetToFormat(fFormat, (float)(fSlider->Value() / fMult));
 			fFloatControl->SetText(value.String());
+			if (modifiers() & B_SHIFT_KEY)
+				fMessage->ReplaceInt32("modifiers", modifiers());
+			else
+				fMessage->ReplaceInt32("modifiers", 0);
+
 			if (fContinuous)
 				_SendMessage((float)(fSlider->Value() / fMult), false);
 		} break;
@@ -110,6 +117,11 @@ ColorFloatSlider::MessageReceived(BMessage* message)
 			BString value;
 			value.SetToFormat(fFormat, (float)(fSlider->Value() / fMult));
 			fFloatControl->SetText(value.String());
+			if (modifiers() & B_SHIFT_KEY)
+				fMessage->ReplaceInt32("modifiers", modifiers());
+			else
+				fMessage->ReplaceInt32("modifiers", 0);
+
 			_SendMessage((float)(fSlider->Value() / fMult), true);
 		} break;
 
@@ -262,6 +274,8 @@ ColorFloatSlider::_InitMessage()
 			fMessage->AddFloat("value", 0.0);
 
 		fMessage->AddBool("final", true);
+		fMessage->AddInt32("modifiers", 0);
+		fMessage->AddPointer("id", this);
 	}
 }
 

--- a/artpaint/controls/ColorPalette.cpp
+++ b/artpaint/controls/ColorPalette.cpp
@@ -103,9 +103,9 @@ ColorPaletteWindow::ColorPaletteWindow(BRect frame, int32 mode)
 	// Here add the buttons that control the color-set.
 	previous_set = new BButton("\xe2\xaf\x87",
 		new BMessage(HS_PREVIOUS_PALETTE));
-	previous_set->SetExplicitMaxSize(BSize(font.StringWidth("XXX"),
+	previous_set->SetExplicitMaxSize(BSize(font.StringWidth("xx\xe2\xaf\x87X"),
 		B_SIZE_UNSET));
-	previous_set->SetExplicitMinSize(BSize(font.StringWidth("XXX"),
+	previous_set->SetExplicitMinSize(BSize(font.StringWidth("xx\xe2\xaf\x87X"),
 		B_SIZE_UNSET));
 	previous_set->SetTarget(this);
 	previous_set->SetToolTip(B_TRANSLATE_COMMENT("Previous color set",
@@ -114,9 +114,9 @@ ColorPaletteWindow::ColorPaletteWindow(BRect frame, int32 mode)
 
 	next_set = new BButton("\xe2\xaf\x88",
 		new BMessage(HS_NEXT_PALETTE));
-	next_set->SetExplicitMaxSize(BSize(font.StringWidth("XXX"),
+	next_set->SetExplicitMaxSize(BSize(font.StringWidth("xx\xe2\xaf\x88X"),
 		B_SIZE_UNSET));
-	next_set->SetExplicitMinSize(BSize(font.StringWidth("XXX"),
+	next_set->SetExplicitMinSize(BSize(font.StringWidth("xx\xe2\xaf\x88X"),
 		B_SIZE_UNSET));
 	next_set->SetTarget(this);
 	next_set->SetToolTip(B_TRANSLATE_COMMENT("Next color set",
@@ -128,7 +128,7 @@ ColorPaletteWindow::ColorPaletteWindow(BRect frame, int32 mode)
 			.Add(color_container, 0, 0, 1, 3)
 			.Add(previous_set, 1, 0)
 			.Add(next_set, 1, 2)
-			.SetInsets(3, 3, 10, 3);
+			.SetInsets(3, 3, 8, 3);
 
 	colorSetGrid->SetMinColumnWidth(0, font.StringWidth("PALETTEPALETTE"));
 
@@ -159,11 +159,22 @@ ColorPaletteWindow::ColorPaletteWindow(BRect frame, int32 mode)
 		.Add(hsvSlider)
 		.Add(color_control);
 
+	rgbSlider->SetExplicitMinSize(
+		BSize(font.StringWidth("XX12345SLIDERSLIDER"), B_SIZE_UNSET));
+	cmySlider->SetExplicitMinSize(
+		BSize(font.StringWidth("XX12345SLIDERSLIDER"), B_SIZE_UNSET));
+	labSlider->SetExplicitMinSize(
+		BSize(font.StringWidth("XX12345SLIDERSLIDER"), B_SIZE_UNSET));
+	hsvSlider->SetExplicitMinSize(
+		BSize(font.StringWidth("XX12345SLIDERSLIDER"), B_SIZE_UNSET));
+	color_control->SetExplicitMinSize(
+		BSize(font.StringWidth("XX12345SLIDERSLIDER"), B_SIZE_UNSET));
+
 	colorPreview = new ColorChip("chippy");
 	colorPreview->SetColor(RGBColorToBGRA(c));
-	colorPreview->SetExplicitMinSize(BSize(color_control->Bounds().Height(),
+	colorPreview->SetExplicitMinSize(BSize(font.StringWidth("#dddddddd#"),
 		B_SIZE_UNSET));
-	colorPreview->SetExplicitMaxSize(BSize(color_control->Bounds().Height(),
+	colorPreview->SetExplicitMaxSize(BSize(font.StringWidth("#dddddddd#"),
 		B_SIZE_UNSET));
 	hexColorField = new BTextControl("", "hex-color", new BMessage(HEX_COLOR_EDITED));
 	for (uint32 i = 0; i < 256; ++i)
@@ -194,11 +205,10 @@ ColorPaletteWindow::ColorPaletteWindow(BRect frame, int32 mode)
 	hexColorField->TextView()->SetMaxBytes(9);
 	hexColorField->SetTarget(this);
 
-	BGridLayout* colorLayout = BLayoutBuilder::Grid<>(B_USE_SMALL_SPACING,
-		B_USE_SMALL_SPACING)
+	BGridLayout* colorLayout = BLayoutBuilder::Grid<>(5, 3)
 		.Add(container_box, 0, 0)
-		.Add(sliderLayout, 1, 0, 2)
-		.AddGroup(B_VERTICAL, B_USE_SMALL_SPACING, 3, 0)
+		.Add(sliderLayout, 1, 0)
+		.AddGroup(B_VERTICAL, B_USE_SMALL_SPACING, 2, 0)
 			.Add(colorPreview)
 			.Add(hexColorField)
 		.End()
@@ -588,7 +598,7 @@ void ColorPaletteWindow::MessageReceived(BMessage *message)
 	case HEX_COLOR_EDITED: {
 		BString hexColor = hexColorField->Text();
 		hexColor.ReplaceAll("#", "");
-		hexColor.ToUpper();
+		hexColor.ToLower();
 		union color_conversion color;
 		bool valid_color = FALSE;
 		if (hexColor.Length() == 3 || hexColor.Length() == 4) {
@@ -681,23 +691,23 @@ ColorPaletteWindow::openControlViews(int32 mode)
 
 	// in this case just open a HSColorControl and color-set container
 		case HS_SIMPLE_COLOR_MODE: {
-			sliderLayout->SetVisibleItem(4);
+			sliderLayout->SetVisibleItem((int32)4);
 		} break;
 	// in this case open an RGBControl
 		case HS_RGB_COLOR_MODE: {
-			sliderLayout->SetVisibleItem(0);
+			sliderLayout->SetVisibleItem((int32)0);
 			color_slider = rgbSlider;
 		}	break;
 		case HS_CMY_COLOR_MODE: {
-			sliderLayout->SetVisibleItem(1);
+			sliderLayout->SetVisibleItem((int32)1);
 			color_slider = cmySlider;
 		}	break;
 		case HS_LAB_COLOR_MODE: {
-			sliderLayout->SetVisibleItem(2);
+			sliderLayout->SetVisibleItem((int32)2);
 			color_slider = labSlider;
 		}	break;
 		case HS_HSV_COLOR_MODE: {
-			sliderLayout->SetVisibleItem(3);
+			sliderLayout->SetVisibleItem((int32)3);
 			color_slider = hsvSlider;
 		}	break;
 
@@ -1049,7 +1059,7 @@ void
 ColorPaletteWindow::SetHexColor(const rgb_color c)
 {
 	BString hexColor;
-	hexColor.SetToFormat("#%02X%02X%02X%02X", c.red, c.green, c.blue, c.alpha);
+	hexColor.SetToFormat("#%02x%02x%02x%02x", c.red, c.green, c.blue, c.alpha);
 	hexColorField->SetText(hexColor);
 }
 

--- a/artpaint/controls/FloatControl.cpp
+++ b/artpaint/controls/FloatControl.cpp
@@ -77,6 +77,11 @@ FloatControl::_InitControl(int32 maxBytes, bool allowNegative, bool continuous)
 
 	TextView()->SetMaxBytes(maxBytes);
 	SetAlignment(B_ALIGN_LEFT, B_ALIGN_RIGHT);
+
+	BFont font;
+	TextView()->SetExplicitMinSize(BSize(font.StringWidth("X") * maxBytes, B_SIZE_UNSET));
+	TextView()->SetExplicitMaxSize(BSize(font.StringWidth("X") * maxBytes, B_SIZE_UNSET));
+
 }
 
 	}	// namespace Interface

--- a/artpaint/controls/FloatSliderControl.cpp
+++ b/artpaint/controls/FloatSliderControl.cpp
@@ -197,6 +197,13 @@ FloatSliderControl::SetResolution(uint8 resolution)
 }
 
 
+BString
+FloatSliderControl::Label() const
+{
+	return fFloatControl->Label();
+}
+
+
 BSlider*
 FloatSliderControl::Slider() const
 {

--- a/artpaint/controls/FloatSliderControl.h
+++ b/artpaint/controls/FloatSliderControl.h
@@ -47,6 +47,8 @@ public:
 			void				SetMinMax(float min, float max);
 			void				SetResolution(uint8 resolution);
 
+			BString				Label() const;
+
 			BSlider*			Slider() const;
 			FloatControl*		TextControl() const;
 

--- a/artpaint/controls/HSVColorControl.cpp
+++ b/artpaint/controls/HSVColorControl.cpp
@@ -89,7 +89,7 @@ HSVColorControl::SetSliderColors(rgb_color c)
  	slider1->Slider()->SetColors(&colorList);
 
  	while (colorList.CountItems() > 0) {
- 		uint32* hue_word = (uint32*)(colorList.RemoveItem(0));
+ 		uint32* hue_word = (uint32*)(colorList.RemoveItem((int32)0));
  		delete hue_word;
  	}
 

--- a/artpaint/controls/MultichannelColorControl.cpp
+++ b/artpaint/controls/MultichannelColorControl.cpp
@@ -30,25 +30,27 @@ MultichannelColorControl::MultichannelColorControl(rgb_color c,
 	font.GetHeight(&height);
 	float barHeight = (height.ascent - height.descent) / 1.5;
 
- 	BMessage *message = new BMessage(SLIDER_CHANGED);
+ 	BMessage* message1 = new BMessage(SLIDER1_CHANGED);
  	slider1 = new ColorFloatSlider(label1,
- 		"0", message, 0, 255, false);
+ 		"0", message1, 0, 255, false);
  	slider1->Slider()->SetBarThickness(barHeight);
 
+	BMessage* message2 = new BMessage(SLIDER2_CHANGED);
  	slider2 = new ColorFloatSlider(label2,
- 		"0", message, 0, 255, false);
+ 		"0", message2, 0, 255, false);
 	slider2->Slider()->SetBarThickness(barHeight);
 
+	BMessage* message3 = new BMessage(SLIDER3_CHANGED);
  	slider3 = new ColorFloatSlider(label3,
- 		"0", message, 0, 255, false);
+ 		"0", message3, 0, 255, false);
 	slider3->Slider()->SetBarThickness(barHeight);
 
+	BMessage* message4 = new BMessage(SLIDER4_CHANGED);
  	slider4 = new ColorFloatSlider(label4,
- 		"0", message, 0, 255, false);
+ 		"0", message4, 0, 255, false);
  	slider4->Slider()->SetBarThickness(barHeight);
 
- 	BGridLayout* sliderGrid = BLayoutBuilder::Grid<>(this,
- 		B_USE_SMALL_SPACING, 0)
+ 	BGridLayout* sliderGrid = BLayoutBuilder::Grid<>(this, 0, 0)
  			.Add(slider1, 0, 0, 0, 0)
  			.Add(slider1->LabelLayoutItem(), 0, 0)
  			.Add(slider1->TextViewLayoutItem(), 1, 0)
@@ -64,12 +66,13 @@ MultichannelColorControl::MultichannelColorControl(rgb_color c,
  			.Add(slider4, 0, 3, 0, 0)
  			.Add(slider4->LabelLayoutItem(), 0, 3)
  			.Add(slider4->TextViewLayoutItem(), 1, 3)
- 			.Add(slider4->Slider(), 2, 3);
- 	sliderGrid->SetColumnWeight(0, 0.2);
+ 			.Add(slider4->Slider(), 2, 3)
+ 			.SetInsets(0, 0, 0, 0);
+ 	sliderGrid->SetColumnWeight(0, 0.1);
 	sliderGrid->SetColumnWeight(1, 0.1);
-	sliderGrid->SetColumnWeight(2, 0.7);
-	sliderGrid->SetMinColumnWidth(1, font.StringWidth("XXX"));
-	sliderGrid->SetMaxColumnWidth(1, font.StringWidth("XXX"));
+	sliderGrid->SetColumnWeight(2, 0.8);
+	sliderGrid->SetMaxColumnWidth(0, font.StringWidth("XXX"));
+	sliderGrid->SetMaxColumnWidth(1, font.StringWidth("XXXXX"));
 
 	SetValue(c);
 }
@@ -114,7 +117,10 @@ void
 MultichannelColorControl::MessageReceived(BMessage* message)
 {
  	switch (message->what) {
- 		case SLIDER_CHANGED: {
+ 		case SLIDER1_CHANGED:
+ 		case SLIDER2_CHANGED:
+ 		case SLIDER3_CHANGED:
+ 		case SLIDER4_CHANGED: {
  			uint32 buttons;
  			BPoint point;
  			GetMouse(&point, &buttons);

--- a/artpaint/controls/MultichannelColorControl.h
+++ b/artpaint/controls/MultichannelColorControl.h
@@ -19,7 +19,10 @@
 #include <String.h>
 
 
-#define SLIDER_CHANGED		'slCh'
+#define SLIDER1_CHANGED		'slCh'
+#define SLIDER2_CHANGED		's2Ch'
+#define SLIDER3_CHANGED		's3Ch'
+#define SLIDER4_CHANGED		's4Ch'
 
 
 using ArtPaint::Interface::ColorFloatSlider;
@@ -34,7 +37,7 @@ virtual				~MultichannelColorControl();
 
 		void		AttachedToWindow();
  		void 		Draw(BRect rect);
- 		void 		MessageReceived(BMessage* message);
+		void 		MessageReceived(BMessage* message);
  		void		SetValue(uint32 val);
 virtual void		SetValue(rgb_color c);
 virtual void		SetValue(float one, float two,

--- a/artpaint/controls/NumberControl.cpp
+++ b/artpaint/controls/NumberControl.cpp
@@ -77,6 +77,11 @@ NumberControl::_InitControl(int32 maxBytes, bool allowNegative, bool continuos)
 
 	TextView()->SetMaxBytes(maxBytes);
 	SetAlignment(B_ALIGN_LEFT, B_ALIGN_RIGHT);
+
+	BFont font;
+	TextView()->SetExplicitMinSize(BSize(font.StringWidth("X") * maxBytes, B_SIZE_UNSET));
+	TextView()->SetExplicitMaxSize(BSize(font.StringWidth("X") * maxBytes, B_SIZE_UNSET));
+
 }
 
 	}	// namespace Interface

--- a/artpaint/controls/NumberSliderControl.cpp
+++ b/artpaint/controls/NumberSliderControl.cpp
@@ -50,7 +50,7 @@ NumberSliderControl::NumberSliderControl(const char* label, const char* text,
 	_InitMessage();
 
 	fNumberControl = new (std::nothrow) NumberControl(label, text,
-		new BMessage(kNumberControlFinished), 3, minRange < 0);
+		new BMessage(kNumberControlFinished), 5, minRange < 0);
 	int32 range = fMaxRange - fMinRange;
 	int32 inc = 1000. / range;
 
@@ -185,6 +185,13 @@ NumberSliderControl::SetMessage(BMessage* message)
 	fMessage = message;
 
 	_InitMessage();
+}
+
+
+BString
+NumberSliderControl::Label() const
+{
+	return fNumberControl->Label();
 }
 
 

--- a/artpaint/controls/NumberSliderControl.h
+++ b/artpaint/controls/NumberSliderControl.h
@@ -44,6 +44,8 @@ public:
 
 			void				SetMessage(BMessage* message);
 
+			BString				Label() const;
+
 			BSlider*			Slider() const;
 			NumberControl*		TextControl() const;
 

--- a/artpaint/controls/RGBColorControl.cpp
+++ b/artpaint/controls/RGBColorControl.cpp
@@ -39,6 +39,56 @@ RGBColorControl::RGBColorControl(rgb_color c)
 
 
 void
+RGBColorControl::MessageReceived(BMessage* message)
+{
+ 	switch (message->what) {
+ 		case SLIDER1_CHANGED:
+ 		case SLIDER2_CHANGED:
+ 		case SLIDER3_CHANGED:
+ 		case SLIDER4_CHANGED: {
+ 			uint32 buttons;
+ 			BPoint point;
+ 			GetMouse(&point, &buttons);
+
+			if (message->HasInt32("modifiers"))
+			{
+				int32 modifiers = message->FindInt32("modifiers");
+ 				if (modifiers & B_SHIFT_KEY) {
+ 					float value;
+
+ 					if (message->what == SLIDER1_CHANGED)
+ 						value = slider1->Value();
+ 					else if (message->what == SLIDER2_CHANGED)
+ 						value = slider2->Value();
+ 					else if (message->what == SLIDER3_CHANGED)
+ 						value = slider3->Value();
+
+ 					if (message->what != SLIDER4_CHANGED) {
+ 						slider1->SetValue(value);
+ 						slider2->SetValue(value);
+ 						slider3->SetValue(value);
+ 					}
+ 				}
+ 			}
+
+ 			SetValue(slider1->Value(),
+ 				slider2->Value(),
+ 				slider3->Value(),
+ 				slider4->Value());
+
+ 			if (buttons != 0 && Message() != NULL)
+ 				if (Message()->HasInt32("buttons"))
+ 					Message()->ReplaceInt32("buttons", buttons);
+
+ 			Invoke();
+ 		} break;
+ 		default:
+ 			BControl::MessageReceived(message);
+ 	}
+}
+
+
+void
 RGBColorControl::SetValue(rgb_color c)
 {
 	MultichannelColorControl::SetValue(c);

--- a/artpaint/controls/RGBColorControl.h
+++ b/artpaint/controls/RGBColorControl.h
@@ -15,8 +15,9 @@
 
 class RGBColorControl : public MultichannelColorControl {
 public:
- 		RGBColorControl(rgb_color c);
+ 					RGBColorControl(rgb_color c);
 
+		void		MessageReceived(BMessage* message);
 virtual	void		SetValue(rgb_color c);
 virtual	void		SetValue(float one, float two,
  							float three, float four);


### PR DESCRIPTION
- decreased size/distance between controls for Color Palette window
- set max width of number controls to be maxBytes * stringwidth of a character

Not sure how much it helped- I tried to trim down the controls and I successfully shrank the text controls - this had the side effect of shrinking them throughout the app, but I looked around and mostly they look fine - except maybe the "canvas size" window.

Unfortunately I can't really shrink the hex value field...the widest value is #DDDDDDDD, and unfortunately most color values are far narrower than #DDDDDDDD, but in order to accommodate that color the field needs to be that wide.

Also, to make the arrow buttons not disappear, I had to make them a tiny bit wider.

Can't seem to get the sliders to shrink more.  The more I think I know about Layout API the less I think I actually know?

Fixes #269 
Fixes #268 ?? 