### PR TITLE
Transparency Settings: Adjust size of text control to space out color wells

### DIFF
--- a/artpaint/controls/FloatControl.cpp
+++ b/artpaint/controls/FloatControl.cpp
@@ -78,11 +78,18 @@ FloatControl::_InitControl(int32 maxBytes, bool allowNegative, bool continuous)
 	TextView()->SetMaxBytes(maxBytes);
 	SetAlignment(B_ALIGN_LEFT, B_ALIGN_RIGHT);
 
-	BFont font;
-	TextView()->SetExplicitMinSize(BSize(font.StringWidth("X") * maxBytes, B_SIZE_UNSET));
-	TextView()->SetExplicitMaxSize(BSize(font.StringWidth("X") * maxBytes, B_SIZE_UNSET));
-
+	SetWidthInBytes(maxBytes);
 }
+
+
+void
+FloatControl::SetWidthInBytes(uint32 bytes)
+{
+	BFont font;
+	TextView()->SetExplicitMinSize(BSize(font.StringWidth("D") * bytes, B_SIZE_UNSET));
+	TextView()->SetExplicitMaxSize(BSize(font.StringWidth("D") * bytes, B_SIZE_UNSET));
+}
+
 
 	}	// namespace Interface
 }	// namespace ArtPaint

--- a/artpaint/controls/FloatControl.h
+++ b/artpaint/controls/FloatControl.h
@@ -25,6 +25,7 @@ public:
 
 			float		Value() const;
 	virtual	void		SetValue(float value);
+			void		SetWidthInBytes(uint32 bytes);
 
 	virtual	void		AttachedToWindow();
 

--- a/artpaint/controls/NumberControl.cpp
+++ b/artpaint/controls/NumberControl.cpp
@@ -78,10 +78,16 @@ NumberControl::_InitControl(int32 maxBytes, bool allowNegative, bool continuos)
 	TextView()->SetMaxBytes(maxBytes);
 	SetAlignment(B_ALIGN_LEFT, B_ALIGN_RIGHT);
 
-	BFont font;
-	TextView()->SetExplicitMinSize(BSize(font.StringWidth("X") * maxBytes, B_SIZE_UNSET));
-	TextView()->SetExplicitMaxSize(BSize(font.StringWidth("X") * maxBytes, B_SIZE_UNSET));
+	SetWidthInBytes(maxBytes);
+}
 
+
+void
+NumberControl::SetWidthInBytes(uint32 bytes)
+{
+	BFont font;
+	TextView()->SetExplicitMinSize(BSize(font.StringWidth("D") * bytes, B_SIZE_UNSET));
+	TextView()->SetExplicitMaxSize(BSize(font.StringWidth("D") * bytes, B_SIZE_UNSET));
 }
 
 	}	// namespace Interface

--- a/artpaint/controls/NumberControl.h
+++ b/artpaint/controls/NumberControl.h
@@ -26,6 +26,7 @@ public:
 
 			int32		Value() const;
 	virtual	void		SetValue(int32 value);
+			void		SetWidthInBytes(uint32 bytes);
 
 	virtual	void		AttachedToWindow();
 

--- a/artpaint/windows/GlobalSetupWindow.cpp
+++ b/artpaint/windows/GlobalSetupWindow.cpp
@@ -419,6 +419,7 @@ GlobalSetupWindow::TransparencyControlView::TransparencyControlView()
 								"0", message, 4, 50, false, true);
 	fGridSizeControl->Slider()->SetExplicitMinSize(BSize(
 		StringWidth("SLIDERSLIDERSLIDERSLIDER"), B_SIZE_UNSET));
+	fGridSizeControl->TextControl()->SetWidthInBytes(7);
 
 	float size = be_plain_font->Size() / 12.0f;
 	BRect frame(0, 0, size * 250, size * 100);
@@ -857,9 +858,7 @@ GlobalSetupWindow::GlobalSetupWindow(const BPoint& leftTop)
 	for (int i = 0; i < fTabView->CountTabs(); i++)
 		width += fTabView->TabFrame(i).Width();
 
-	width += be_plain_font->StringWidth(B_TRANSLATE("Grid size:"));
-
-	fTabView->SetExplicitMinSize(BSize(width, B_SIZE_UNSET));
+	fTabView->SetExplicitMinSize(BSize(width + 2 * be_plain_font->Size(), B_SIZE_UNSET));
 }
 
 


### PR DESCRIPTION
Adjusted size of text control in Transparency settings to space out color swatches

- added method 'SetWidthInBytes' to NumberControl and FloatControl to allow adjustments of layouts.

Fixes #274 