### PR TITLE
GlobalSettings: fix messages for cursor settings and remove quit confirm

### DIFF
--- a/artpaint/windows/GlobalSetupWindow.cpp
+++ b/artpaint/windows/GlobalSetupWindow.cpp
@@ -702,7 +702,6 @@ private:
 
 		BRadioButton*	fToolCursor;
 		BRadioButton*	fCrossHairCursor;
-		BCheckBox*		fConfirmShutdown;
 };
 
 
@@ -722,18 +721,10 @@ GlobalSetupWindow::MiscControlView::MiscControlView()
 		.AddGroup(B_VERTICAL, B_USE_SMALL_SPACING)
 			.Add(fToolCursor =
 				new BRadioButton(B_TRANSLATE("Tool cursor"),
-				new BMessage(kCrossHairCursorMode)))
+				new BMessage(kToolCursorMode)))
 			.Add(fCrossHairCursor =
 				new BRadioButton(B_TRANSLATE("Cross-hair cursor"),
-				new BMessage(kToolCursorMode)))
-			.SetInsets(B_USE_DEFAULT_SPACING, 0, 0, 0)
-		.End()
-		.Add(BSpaceLayoutItem::CreateVerticalStrut(B_USE_DEFAULT_SPACING))
-		.Add(labelApp)
-		.AddGroup(B_VERTICAL, B_USE_SMALL_SPACING)
-			.Add(fConfirmShutdown =
-				new BCheckBox(B_TRANSLATE("Confirm quitting"),
-				new BMessage(kConfirmShutdownChanged)))
+				new BMessage(kCrossHairCursorMode)))
 			.SetInsets(B_USE_DEFAULT_SPACING, 0, 0, 0)
 		.End()
 		.AddGlue()
@@ -746,13 +737,10 @@ GlobalSetupWindow::MiscControlView::MiscControlView()
 		BMessage settings;
 		server->GetApplicationSettings(&settings);
 		settings.FindInt32(skCursorMode, &fCursorMode);
-		settings.FindInt32(skQuitConfirmMode, &fShutdownMode);
 	}
 
 	if (fCursorMode == CROSS_HAIR_CURSOR_MODE)
 		fCrossHairCursor->SetValue(B_CONTROL_ON);
-
-	fConfirmShutdown->SetValue(fShutdownMode);
 }
 
 
@@ -764,7 +752,6 @@ GlobalSetupWindow::MiscControlView::AttachedToWindow()
 
 	fToolCursor->SetTarget(this);
 	fCrossHairCursor->SetTarget(this);
-	fConfirmShutdown->SetTarget(this);
 }
 
 
@@ -778,10 +765,6 @@ GlobalSetupWindow::MiscControlView::MessageReceived(BMessage* message)
 
 		case kCrossHairCursorMode: {
 			fCursorMode = CROSS_HAIR_CURSOR_MODE;
-		}	break;
-
-		case kConfirmShutdownChanged: {
-			fShutdownMode = fConfirmShutdown->Value();
 		}	break;
 
 		default: {


### PR DESCRIPTION
Ok, the cursor setting problem was the silliest thing - the messages were opposite of the buttons!  So if you clicked "tool cursor" in the code it selected cross-hair mode, and vice versa.  That's why it didn't seem to ever work.  Now it works, you can choose cursor modes.  

possible improvements: 
- seems like the cursor stays as the finger pointer unless you leave the canvas and return. It'd be nice if it updated whenever you're on the canvas. Some kind of refresh issue?
- maybe my eyes are getting older but I find the cursors hard to see on the alpha checkerboard, even when I tried different colors. Maybe they can be made 2 pixels thick instead of 1?  

I also removed the quit confirm while in there.  I agree it's pretty useless.

Fixes #132 
Fixes #133 
