### PR TITLE
Select-all: add 'select all' function to select entire canvas

### DIFF
--- a/artpaint/application/MessageConstants.h
+++ b/artpaint/application/MessageConstants.h
@@ -103,6 +103,7 @@
 // these constants are used in the Edit-menu
 #define	HS_INVERT_SELECTION		'InSl'
 #define	HS_CLEAR_SELECTION		'ClSl'
+#define HS_SELECT_ALL			'SlAl'
 #define HS_GROW_SELECTION		'GrSl'
 #define HS_SHRINK_SELECTION		'SrSL'
 

--- a/artpaint/application/Selection.cpp
+++ b/artpaint/application/Selection.cpp
@@ -255,6 +255,22 @@ Selection::AddSelection(BBitmap *bitmap, bool add_to_selection)
 
 
 void
+Selection::SelectAll()
+{
+	BPoint* corners = new BPoint[4];
+
+	corners[0] = image_bounds.LeftTop();
+	corners[1] = image_bounds.RightTop();
+	corners[2] = image_bounds.RightBottom();
+	corners[3] = image_bounds.LeftBottom();
+
+	HSPolygon* bound_poly = new (std::nothrow) HSPolygon(corners, 4);
+	bound_poly->ChangeDirection(HS_POLYGON_CLOCKWISE);
+	AddSelection(bound_poly, true);
+}
+
+
+void
 Selection::Clear()
 {
 	if (original_selections) {

--- a/artpaint/application/Selection.h
+++ b/artpaint/application/Selection.h
@@ -112,12 +112,14 @@ void	StartDrawing(BView*,float);
 // The parameter point-list is not copied and thus should not be deleted in the calling function.
 void	AddSelection(HSPolygon*,bool add_to_selection=TRUE);
 
-
 // This function adds a binary bitmap to the selection.
 void	AddSelection(BBitmap*,bool add_to_selection);
 
 // This function clears the selection.
 void	Clear();
+
+// this function selects the entire canvas
+void	SelectAll();
 
 // This dilates the selection map so that the size of the selection will increase
 void	Dilatate();

--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -614,6 +614,21 @@ ImageView::MessageReceived(BMessage* message)
 			}
 		} break;
 
+		case HS_SELECT_ALL: {
+			if (!fManipulator) {
+				selection->SelectAll();
+				if (!(*undo_queue->ReturnSelectionData() == *selection->ReturnSelectionData())) {
+					UndoEvent *new_event = undo_queue->AddUndoEvent(B_TRANSLATE("Select all"),
+						the_image->ReturnThumbnailImage());
+					if (new_event != NULL) {
+						new_event->SetSelectionData(undo_queue->ReturnSelectionData());
+						undo_queue->SetSelectionData(selection->ReturnSelectionData());
+					}
+				}
+				Invalidate();
+			}
+		} break;
+
 		case HS_GROW_SELECTION: {
 			if (!fManipulator) {
 				selection->Dilatate();

--- a/artpaint/paintwindow/PaintWindow.cpp
+++ b/artpaint/paintwindow/PaintWindow.cpp
@@ -1155,6 +1155,9 @@ PaintWindow::openMenuBar()
 
 	menu->AddItem(new BSeparatorItem());
 
+	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Select all"),
+		new BMessage(HS_SELECT_ALL), 'A', 0, this,
+		B_TRANSLATE("Selects entire canvas")));
 	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Grow selection"),
 		new BMessage(HS_GROW_SELECTION), 'G', 0, this,
 		B_TRANSLATE("Grows the selection in all directions.")));


### PR DESCRIPTION
Here's the ALT+A to select the entire canvas.  Haven't decided what to do about the "select all non-transparent pixels" yet as that's an awfully long menu item. :smile: 

Fixes #154 
