### PR TITLE
Selector Tool: Ensure initial point for intelligent scissors is within canvas

### DIFF
--- a/artpaint/tools/SelectorTool.cpp
+++ b/artpaint/tools/SelectorTool.cpp
@@ -89,6 +89,10 @@ SelectorTool::UseTool(ImageView *view, uint32 buttons, BPoint point,
 	window->Unlock();
 
 	if (fToolSettings.shape == HS_INTELLIGENT_SCISSORS) {
+		if (buffer->Bounds().Contains(point) == FALSE) {
+			return NULL;
+		}
+
 		IntelligentPathFinder *path_finder =
 			new IntelligentPathFinder(view->ReturnImage()->ReturnActiveBitmap());
 		HSPolygon *the_polygon = new HSPolygon(&point,1);


### PR DESCRIPTION
Fixes #306 