### PR TITLE
Ellipse/Rectangle: Use modifiers for SHIFT and ALT instead of modes

### DIFF
--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -1419,7 +1419,7 @@ ImageView::PaintToolThread()
 
 	int32 tool_type = ToolManager::Instance().ReturnActiveToolType();
 
-	if (modifiers() & B_COMMAND_KEY)
+	if (modifiers() & B_CONTROL_KEY)
 		tool_type = COLOR_SELECTOR_TOOL;
 
 	if (tool_type != TEXT_TOOL) {

--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,4 +1,4 @@
-1	English	application/x-vnd.artpaint	3348436892
+1	English	application/x-vnd.artpaint	3060624465
 Angle:	Manipulators		Angle:
 Cancel	Windows		Cancel
 Lighten	PixelOperations		Lighten
@@ -26,7 +26,7 @@ Alpha	Tools		Alpha
 Creates a new empty canvas.	PaintWindow		Creates a new empty canvas.
 Channel b	ColorSliders	For CIELAB color sliders - also called L*a*b* color	Channel b
 ArtPaint	System name		ArtPaint
-Rectangle: SHIFT for square	Tools		Rectangle: SHIFT for square
+Ellipse: SHIFT for circle, ALT for centered	Tools		Ellipse: SHIFT for circle, ALT for centered
 Airbrush tool	Tools		Airbrush tool
 Rectangle tool	Tools		Rectangle tool
 Not enough free memory to start the effect you requested. You may close other images and try again. Also shortening the depth of undo or disabling undo altogether helps in achieving more memory. If you have other applications running, closing them gives you more free memory. It is also a good idea to save your work at this point, because if the memory runs out completely saving might become impossible. I am very sorry about this inconvenience.	ImageView		Not enough free memory to start the effect you requested. You may close other images and try again. Also shortening the depth of undo or disabling undo altogether helps in achieving more memory. If you have other applications running, closing them gives you more free memory. It is also a good idea to save your work at this point, because if the memory runs out completely saving might become impossible. I am very sorry about this inconvenience.
@@ -108,8 +108,8 @@ Save project	PaintWindow		Save project
 Spray	Tools		Spray
 Colors:	Windows		Colors:
 None	Tools		None
-Save format:	FilePanels		Save format:
 Clears all layers.	PaintWindow		Clears all layers.
+Save format:	FilePanels		Save format:
 Drop layer to copy it to this image.	ImageView		Drop layer to copy it to this image.
 Zoom in	PaintWindow		Zoom in
 Rotate +90°	PaintWindow		Rotate +90°
@@ -142,6 +142,7 @@ Making a fill.	Tools		Making a fill.
 Speed:	Tools		Speed:
 Close	PaintWindow		Close
 Click to place the text.	Tools		Click to place the text.
+Selects entire canvas	PaintWindow		Selects entire canvas
 Translate…	PaintWindow		Translate…
 Shrinks the selection in all directions.	PaintWindow		Shrinks the selection in all directions.
 Text tool	Tools		Text tool
@@ -175,8 +176,8 @@ Sets the grid to 2 by 2 pixels.	PaintWindow		Sets the grid to 2 by 2 pixels.
 Black	ColorSliders	For CMYK color slider	Black
 Reset brush	Tools		Reset brush
 Undo steps:	Windows		Undo steps:
-Magenta	ColorSliders	For CMYK color slider	Magenta
 Clear canvas	PaintWindow		Clear canvas
+Magenta	ColorSliders	For CMYK color slider	Magenta
 OK	ColorPalette		OK
 Using the airbrush.	Tools		Using the airbrush.
 Tool setup…	PaintWindow		Tool setup…
@@ -216,8 +217,8 @@ Blue	Tools		Blue
 Height:	PaintWindow		Height:
 Click to use the tool.	Tools		Click to use the tool.
 Merge down	Image		Merge down
-Color burn	PixelOperations		Color burn
 Window	PaintWindow		Window
+Color burn	PixelOperations		Color burn
 ArtPaint project format containing layers etc.	PaintApplication	MIME type long description	ArtPaint project format containing layers etc.
 Open image…	PaintWindow		Open image…
 Saves the project to disk.	PaintWindow		Saves the project to disk.
@@ -230,10 +231,10 @@ Brush	Windows		Brush
 Hairy brush tool	Tools		Hairy brush tool
 Blur tool	Tools		Blur tool
 Adjustable	Windows		Adjustable
-Center to corner	Tools		Center to corner
 About ArtPaint	PaintWindow		About ArtPaint
 Linear dodge	PixelOperations		Linear dodge
 Don't save	ImageView		Don't save
+Select all	PaintWindow		Select all
 Tools	Tools		Tools
 Save image as…	PaintWindow		Save image as…
 Brushes	Windows		Brushes
@@ -306,6 +307,7 @@ Hairs:	Tools		Hairs:
 Behavior	Tools		Behavior
 Saturation	ColorSliders	For HSV color slider	Saturation
 Grow selection	PaintWindow		Grow selection
+Select all	ImageView		Select all
 Flood fill	Tools		Flood fill
 ArtPaint is a painting and image-processing program for Haiku.	PaintApplication		ArtPaint is a painting and image-processing program for Haiku.
 Grid size:	Windows		Grid size:
@@ -319,7 +321,6 @@ Continuous	Tools		Continuous
 OK	PaintWindow		OK
 Sets the grid to 4 by 4 pixels.	PaintWindow		Sets the grid to 4 by 4 pixels.
 User manual…	PaintWindow		User manual…
-Corner to corner	Tools		Corner to corner
 Lightness	ColorSliders	For CIELAB color sliders - also called L*a*b* color	Lightness
 Opens the layers window.	PaintWindow		Opens the layers window.
 Transparency	Windows		Transparency
@@ -340,13 +341,13 @@ Choose format	FilePanels		Choose format
 Cancel	FilePanels		Cancel
 Mode	Tools		Mode
 Flip horizontally	PaintWindow		Flip horizontally
-Ellipse: SHIFT for circle	Tools		Ellipse: SHIFT for circle
 Duplicates the selected layer.	PaintWindow		Duplicates the selected layer.
 Overlay	PixelOperations		Overlay
 Clears the active layer.	PaintWindow		Clears the active layer.
 Clear layer	Image		Clear layer
 Quit	PaintWindow		Quit
 Rotate…	PaintWindow		Rotate…
+Rectangle: SHIFT for square, ALT for centered	Tools		Rectangle: SHIFT for square, ALT for centered
 No configuration options available.	Tools		No configuration options available.
 Open color set…	ColorPalette		Open color set…
 Wand tolerance	Tools		Wand tolerance


### PR DESCRIPTION
- SHIFT maintains "square" aspect ratio
- ALT uses center-to-corner mode
- removed radio buttons for modes; added to help string
- also draw with current fg color instead of just black

Part of #126 
