### PR TITLE
Selection: include any non-zero pixel in selection

### DIFF
--- a/artpaint/application/Selection.h
+++ b/artpaint/application/Selection.h
@@ -185,7 +185,7 @@ Selection::ContainsPoint(BPoint p)
 	int32 x = (int32)p.x;
 
 	return (selection_bits == NULL || (image_bounds.Contains(p) &&
-		((*(selection_bits + y * selection_bpr + x)) & 0x01)));
+		((*(selection_bits + y * selection_bpr + x)) != 0x00)));
 }
 
 
@@ -193,7 +193,7 @@ bool
 Selection::ContainsPoint(int32 x, int32 y)
 {
 	return (selection_bits == NULL ||
-		((*(selection_bits + y * selection_bpr + x)) & 0x01));
+		((*(selection_bits + y * selection_bpr + x)) != 0x00));
 }
 
 


### PR DESCRIPTION
After a lot of digging and refactoring and rewriting it turns out the issue is simply that freehand selections have antialiased edges and the not-solid-white edge pixels aren't detected.

Fixes #286 
