### PR TITLE
Selection: make sure pixel in SimplifySelection stays in bounds

### DIFF
--- a/artpaint/application/Selection.cpp
+++ b/artpaint/application/Selection.cpp
@@ -899,6 +899,8 @@ Selection::SimplifySelection()
 						}
 
 						next_point = BPoint(new_x, new_y);
+						if (bounds.Contains(next_point) == FALSE)
+							direction = -1;
 					}
 
 					HSPolygon* new_polygon;


### PR DESCRIPTION
Added a check to prevent runaway selections - seems to happen on "all non-transparent" sometimes.  