### PR TITLE
ImageView: clearing layer, selection, or canvas should clear it

### DIFF
--- a/artpaint/application/MessageConstants.h
+++ b/artpaint/application/MessageConstants.h
@@ -109,10 +109,8 @@
 #define HS_HIDE_SELECTION_BORDERS	'HbSL'
 #define HS_SELECT_LAYER_PIXELS		'SlPx'
 
-// These constants are used to inform about clearing of
-// the canvas or a individual layer.
-#define	HS_CLEAR_CANVAS			'Clcv'
-#define HS_CLEAR_LAYER			'Clla'
+// These constants are used to inform about deleting a layer or selection
+#define HS_EDIT_DELETE			'Clla'
 
 // This constant is used in a message that contains
 // an int32 'mode' that describes the new mode for ImageView.

--- a/artpaint/paintwindow/Image.cpp
+++ b/artpaint/paintwindow/Image.cpp
@@ -493,7 +493,7 @@ Image::ClearCurrentLayer(rgb_color &c)
 	cleared_layer->Clear(c);
 
 	// Store the undo.
-	UndoEvent *new_event = undo_queue->AddUndoEvent(B_TRANSLATE("Clear layer"),ReturnThumbnailImage());
+	UndoEvent *new_event = undo_queue->AddUndoEvent(B_TRANSLATE("Delete"),ReturnThumbnailImage());
 	if (new_event != NULL) {
 		for (int32 i=0;i<layer_list->CountItems();i++) {
 			Layer *layer = (Layer*)layer_list->ItemAt(i);
@@ -506,40 +506,6 @@ Image::ClearCurrentLayer(rgb_color &c)
 
 			new_event->AddAction(new_action);
 			new_action->StoreUndo(layer->Bitmap());
-		}
-	}
-
-	// If the added UndoEvent is empty then destroy it. This is because there was nothing
-	// to be cleared.
-	if ((new_event != NULL) && (new_event->IsEmpty() == TRUE)) {
-		undo_queue->RemoveEvent(new_event);
-		delete new_event;
-		return FALSE;
-	}
-
-	Render();
-	return TRUE;
-}
-
-
-bool
-Image::ClearLayers(rgb_color &c)
-{
-	for (int32 i=0;i<layer_list->CountItems();i++) {
-		((Layer*)layer_list->ItemAt(i))->Clear(c);
-	}
-
-	// Store the undo.
-	UndoEvent *new_event = undo_queue->AddUndoEvent(B_TRANSLATE("Clear canvas"),ReturnThumbnailImage());
-	if (new_event != NULL) {
-		for (int32 i=0;i<layer_list->CountItems();i++) {
-			Layer *layer = (Layer*)layer_list->ItemAt(i);
-			UndoAction *new_action;
-			new_action = new UndoAction(layer->Id(),CLEAR_LAYER_ACTION,layer->Bitmap()->Bounds());
-			new_event->AddAction(new_action);
-			new_action->StoreUndo(layer->Bitmap());
-			thread_id a_thread = spawn_thread(Layer::CreateMiniatureImage,"create mini picture",B_LOW_PRIORITY,layer);
-			resume_thread(a_thread);
 		}
 	}
 

--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -736,24 +736,11 @@ ImageView::MessageReceived(BMessage* message)
 			Invalidate();
 		} break;
 
-		// this comes from menubar->"Canvas"->"Clear Canvas", we should then clear all the
-		// layers and recalculate the composite picture and redisplay
-		case HS_CLEAR_CANVAS: {
+		// This comes from menubar->"Edit"->"Delete". We should clear the layer,
+		// recalculate the composite picture and redisplay the image.
+		case HS_EDIT_DELETE: {
 			if (acquire_sem_etc(action_semaphore, 1, B_TIMEOUT, 0) == B_OK) {
-				rgb_color c = ((PaintApplication*)be_app)->Color(FALSE);
-				if (the_image->ClearLayers(c) == TRUE) {
-					Invalidate();
-					AddChange();
-				}
-				release_sem(action_semaphore);
-			}
-		} break;
-
-		// This comes from menubar->"Layer"->"Clear Layer". We should clear the layer, recalculate
-		// the composite picture and redisplay the image.
-		case HS_CLEAR_LAYER: {
-			if (acquire_sem_etc(action_semaphore, 1, B_TIMEOUT, 0) == B_OK) {
-				rgb_color c = ((PaintApplication*)be_app)->Color(FALSE);
+				rgb_color c = BGRAColorToRGB(0);
 				if (the_image->ClearCurrentLayer(c) == TRUE) {
 					Invalidate();
 					AddChange();
@@ -2122,9 +2109,7 @@ ImageView::DoCopyOrCut(int32 layers, bool cut)
 		}
 		if (cut == TRUE) {
 			if (layers == HS_MANIPULATE_CURRENT_LAYER)
-				Window()->PostMessage(HS_CLEAR_LAYER, this);
-			else
-				Window()->PostMessage(HS_CLEAR_CANVAS, this);
+				Window()->PostMessage(HS_EDIT_DELETE, this);
 		}
 
 		release_sem(action_semaphore);

--- a/artpaint/paintwindow/PaintWindow.cpp
+++ b/artpaint/paintwindow/PaintWindow.cpp
@@ -1160,6 +1160,12 @@ PaintWindow::openMenuBar()
 		new BMessage(B_PASTE), 'V', B_SHIFT_KEY, this,
 		B_TRANSLATE("Pastes previously copied selection as a new project.")));
 
+	menu->AddSeparatorItem();
+
+	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Delete"),
+		new BMessage(HS_EDIT_DELETE), 0, 0, this,
+		B_TRANSLATE("Clears the selection or layer.")));
+
 	menu = new BMenu(B_TRANSLATE("Selection"));
 	fMenubar->AddItem(menu);
 
@@ -1223,8 +1229,6 @@ PaintWindow::openMenuBar()
 		a_message, B_UP_ARROW, 0, this,
 		B_TRANSLATE("Flips the active layer vertically.")));
 
-	menu->AddSeparatorItem();
-
 /*
 	a_message = new BMessage(HS_START_MANIPULATOR);
 	a_message->AddInt32("manipulator_type",TRANSPARENCY_MANIPULATOR);
@@ -1233,9 +1237,6 @@ PaintWindow::openMenuBar()
 		a_message, 0, 0, this,
 		B_TRANSLATE("Changes the transparency of active layer.")));
 */
-	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Clear"),
-		new BMessage(HS_CLEAR_LAYER), 0, 0, this,
-		B_TRANSLATE("Clears the active layer.")));
 
 	menu->AddSeparatorItem();
 
@@ -1311,11 +1312,6 @@ PaintWindow::openMenuBar()
 	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Scale" B_UTF8_ELLIPSIS),
 		a_message, 'S', B_CONTROL_KEY, this,
 		B_TRANSLATE("Scales the image.")));
-
-	menu->AddItem(new BSeparatorItem());
-	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Clear"),
-		new BMessage(HS_CLEAR_CANVAS), 0, 0, this,
-		B_TRANSLATE("Clears all layers.")));
 
 	// The Window menu,
 	menu = new BMenu(B_TRANSLATE("Window"));
@@ -1574,8 +1570,7 @@ PaintWindow::AddImageView()
 	fMenubar->FindItem(HS_DUPLICATE_LAYER)->SetTarget(fImageView);
 	fMenubar->FindItem(HS_MERGE_WITH_LOWER_LAYER)->SetTarget(fImageView);
 	fMenubar->FindItem(B_TRANSLATE("Crop" B_UTF8_ELLIPSIS))->SetTarget(fImageView);
-	fMenubar->FindItem(HS_CLEAR_CANVAS)->SetTarget(fImageView);
-	fMenubar->FindItem(HS_CLEAR_LAYER)->SetTarget(fImageView);
+	fMenubar->FindItem(HS_EDIT_DELETE)->SetTarget(fImageView);
 	fMenubar->FindItem(HS_ZOOM_IMAGE_IN)->SetTarget(fImageView);
 	fMenubar->FindItem(HS_ZOOM_IMAGE_OUT)->SetTarget(fImageView);
 	fMenubar->FindItem(B_TRANSLATE("Set zoom level"))->Submenu()->SetTargetForItems(fImageView);


### PR DESCRIPTION
- moved Layer->Clear to Edit->Delete as it's more accurate
- this also fixes Edit->Cut

I tried to use a shortcut but all menu shortcuts HAVE to start with ALT, and also with B_DELETE and B_BACKSPACE, nothing shows up in the menu shortcut, so it looks weird to just show "ALT" when the shortcut is "ALT+DEL"  - so I left it with no shortcut for now.

Fixes #354 