### PR TITLE
RotationManipulator: added SHIFT to snap to 22.5 degree angles

### DIFF
--- a/artpaint/application/UtilityClasses.cpp
+++ b/artpaint/application/UtilityClasses.cpp
@@ -115,14 +115,14 @@ MakeRectFromPoints(const BPoint& point1, const BPoint& point2)
 
 
 float
-SnapToAngle(const float snap_angle, const float src_angle)
+SnapToAngle(const float snap_angle, const float src_angle, const float max_angle)
 {
 	float new_angle = src_angle;
 
-	if (src_angle > 90)
-		new_angle = -(90. - ((int32)src_angle % 90));
-	if (src_angle < -90)
-		new_angle = 90. - ((int32)-src_angle % 90);
+	if (src_angle > max_angle)
+		new_angle = -(max_angle - ((int32)src_angle % (int32)max_angle));
+	if (src_angle < -max_angle)
+		new_angle = max_angle - ((int32)-src_angle % (int32)max_angle);
 
 	float abs_src_angle = fabs(new_angle);
 	float abs_snap_angle = fabs(snap_angle);
@@ -132,7 +132,7 @@ SnapToAngle(const float snap_angle, const float src_angle)
 	if (new_angle < 0)
 		sign = -1;
 
-	for (float i = 0; i <= 90; i += abs_snap_angle) {
+	for (float i = 0; i <= max_angle; i += abs_snap_angle) {
 		if (abs_src_angle > i - half_angle && abs_src_angle < i + half_angle) {
 			new_angle = i;
 			return new_angle * sign;

--- a/artpaint/application/UtilityClasses.h
+++ b/artpaint/application/UtilityClasses.h
@@ -49,7 +49,8 @@ public:
 BRect FitRectToScreen(BRect source);
 BRect CenterRectOnScreen(BRect source);
 BRect MakeRectFromPoints(const BPoint& point1, const BPoint& point2);
-float SnapToAngle(const float snap_angle, const float src_angle);
+float SnapToAngle(const float snap_angle, const float src_angle,
+	const float max_angle = 90.);
 
 
 inline uint32

--- a/artpaint/viewmanipulators/RotationManipulator.cpp
+++ b/artpaint/viewmanipulators/RotationManipulator.cpp
@@ -15,6 +15,7 @@
 #include "PixelOperations.h"
 #include "RotationManipulator.h"
 #include "Selection.h"
+#include "UtilityClasses.h"
 
 
 #include <Catalog.h>
@@ -180,19 +181,27 @@ RotationManipulator::MouseDown(BPoint point, uint32 buttons, BView*, bool first_
 		float dy = point.y - settings->origo.y;
 		float dx = point.x - settings->origo.x;
 		new_angle = atan2(dy, dx);
-		new_angle = new_angle / PI *180;
+		new_angle = new_angle / PI * 180;
 		if (first_click == TRUE) {
+			if (modifiers() & B_SHIFT_KEY)
+				new_angle = SnapToAngle(22.5, new_angle, 360.);
+
 			starting_angle = new_angle;
-		}
-		else {
+		} else {
+			float delta = settings->angle + new_angle - starting_angle;
+			if (modifiers() & B_SHIFT_KEY) {
+				delta = SnapToAngle(22.5, delta, 360.);
+				new_angle = delta - settings->angle + starting_angle;
+			}
+
 			settings->angle += new_angle - starting_angle;
+
 			starting_angle = new_angle;
 			if ((config_view != NULL) && (new_angle != previous_angle)) {
 				config_view->SetAngle(settings->angle);
 			}
 		}
-	}
-	else {
+	} else {
 		// Set the new origo for rotation and reset the angle.
 		previous_angle = settings->angle;
 		settings->angle = 0;
@@ -611,7 +620,9 @@ RotationManipulator::SetAngle(float angle)
 const char*
 RotationManipulator::ReturnHelpString()
 {
-	return B_TRANSLATE("Rotate: Left-drag to rotate, right-click to set rotation center.");
+	return B_TRANSLATE("Rotate: Left-drag to rotate, " \
+		"right-click to set rotation center, " \
+		"SHIFT to snap angle.");
 }
 
 


### PR DESCRIPTION
...also (by necessity) updated SnapToAngle() function to allow different max angles rather than just 90

Point of note, the angle values in the manipulator dialog might seem strange but they are strange even without snapping.  I don't know how much it matters as you can always type in a specific angle if you wish, and the visual is what's really most important.  

Fixes #330 

Fixes #126

