### PR TITLE
Manipulators: refactor so selection is a class member

### DIFF
--- a/addons/AddOns/AdaptiveHistogramEqualization/AHEManipulator.cpp
+++ b/addons/AddOns/AdaptiveHistogramEqualization/AHEManipulator.cpp
@@ -40,7 +40,8 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 
 
 AHEManipulator::AHEManipulator(BBitmap*)
-		: Manipulator()
+		: Manipulator(),
+		selection(NULL)
 {
 }
 
@@ -50,7 +51,7 @@ AHEManipulator::~AHEManipulator()
 }
 
 
-BBitmap* AHEManipulator::ManipulateBitmap(BBitmap *original, Selection *selection, BStatusBar*)
+BBitmap* AHEManipulator::ManipulateBitmap(BBitmap *original, BStatusBar*)
 {
 	// This manipulator assumes a grayscale image
 	ImageProcessingLibrary iplib;

--- a/addons/AddOns/AdaptiveHistogramEqualization/AHEManipulator.h
+++ b/addons/AddOns/AdaptiveHistogramEqualization/AHEManipulator.h
@@ -13,14 +13,18 @@
 
 class AHEManipulator : public Manipulator {
 BBitmap		*target_bitmap;
+Selection	*selection;
 
 public:
 			AHEManipulator(BBitmap*);
 			~AHEManipulator();
 
-BBitmap*	ManipulateBitmap(BBitmap*,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap*, BStatusBar*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
+
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 #endif	// _AHE_MANIPULATOR_H

--- a/addons/AddOns/AntiDitherer/AntiDitherer.cpp
+++ b/addons/AddOns/AntiDitherer/AntiDitherer.cpp
@@ -46,7 +46,8 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 
 
 AntiDithererManipulator::AntiDithererManipulator(BBitmap *bm)
-		: WindowGUIManipulator()
+		: WindowGUIManipulator(),
+		selection(NULL)
 {
 	preview_bitmap = NULL;
 	config_view = NULL;
@@ -63,7 +64,9 @@ AntiDithererManipulator::~AntiDithererManipulator()
 }
 
 
-BBitmap* AntiDithererManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* AntiDithererManipulator::ManipulateBitmap(ManipulatorSettings* set,
+	BBitmap* original,
+	BStatusBar* status_bar)
 {
 	AntiDithererManipulatorSettings *new_settings = cast_as(set,AntiDithererManipulatorSettings);
 
@@ -93,7 +96,8 @@ BBitmap* AntiDithererManipulator::ManipulateBitmap(ManipulatorSettings *set,BBit
 	return target_bitmap;
 }
 
-int32 AntiDithererManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRegion *updated_region)
+int32 AntiDithererManipulator::PreviewBitmap(bool full_quality,
+	BRegion* updated_region)
 {
 	updated_region->Set(preview_bitmap->Bounds());
 
@@ -129,7 +133,7 @@ void AntiDithererManipulator::SetPreviewBitmap(BBitmap *bm)
 }
 
 
-void AntiDithererManipulator::Reset(Selection*)
+void AntiDithererManipulator::Reset()
 {
 	if (copy_of_the_preview_bitmap != NULL) {
 		// memcpy seems to be about 10-15% faster that copying with a loop.

--- a/addons/AddOns/AntiDitherer/AntiDitherer.h
+++ b/addons/AddOns/AntiDitherer/AntiDitherer.h
@@ -75,15 +75,16 @@ class AntiDithererManipulator : public WindowGUIManipulator {
 			BBitmap	*target_bitmap;
 
 void		anti_dither();
+Selection*	selection;
 
 public:
 			AntiDithererManipulator(BBitmap*);
 			~AntiDithererManipulator();
 
 void		MouseDown(BPoint,uint32 buttons,BView*,bool);
-int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion* =NULL);
-BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
-void		Reset(Selection*);
+int32		PreviewBitmap(bool full_quality = FALSE, BRegion* =NULL);
+BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
+void		Reset();
 void		SetPreviewBitmap(BBitmap*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
@@ -93,6 +94,8 @@ ManipulatorSettings*	ReturnSettings();
 BView*		MakeConfigurationView(const BMessenger& target);
 
 void		ChangeSettings(ManipulatorSettings*);
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 

--- a/addons/AddOns/Blur/Blur.cpp
+++ b/addons/AddOns/Blur/Blur.cpp
@@ -47,7 +47,8 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 
 
 BlurManipulator::BlurManipulator(BBitmap *bm)
-		: WindowGUIManipulator()
+		: WindowGUIManipulator(),
+		selection(NULL)
 {
 	preview_bitmap = NULL;
 	wide_copy_of_the_preview_bitmap = NULL;
@@ -77,9 +78,10 @@ BlurManipulator::~BlurManipulator()
 }
 
 
-BBitmap* BlurManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* BlurManipulator::ManipulateBitmap(ManipulatorSettings* set,
+	BBitmap* original, BStatusBar* status_bar)
 {
-	BlurManipulatorSettings *new_settings = dynamic_cast<BlurManipulatorSettings*>(set);
+	BlurManipulatorSettings* new_settings = dynamic_cast<BlurManipulatorSettings*>(set);
 
 	if (new_settings == NULL)
 		return NULL;
@@ -110,7 +112,7 @@ BBitmap* BlurManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *ori
 }
 
 
-int32 BlurManipulator::PreviewBitmap(Selection *sel, bool full_quality,BRegion *updated_region)
+int32 BlurManipulator::PreviewBitmap(bool full_quality, BRegion* updated_region)
 {
 	updated_region->Set(preview_bitmap->Bounds());
 //	if ((settings == previous_settings) == FALSE) {
@@ -150,7 +152,7 @@ int32 BlurManipulator::PreviewBitmap(Selection *sel, bool full_quality,BRegion *
 		final_bpr = preview_bitmap->BytesPerRow()/4;
 		final_width = preview_bitmap->Bounds().Width();
 		final_height = preview_bitmap->Bounds().Height();
-		selection = sel;
+		//selection = sel;
 		status_bar = NULL;
 		blur_amount = settings.blur_amount;
 		previous_settings = settings;
@@ -513,7 +515,7 @@ void BlurManipulator::SetPreviewBitmap(BBitmap *bm)
 }
 
 
-void BlurManipulator::Reset(Selection*)
+void BlurManipulator::Reset()
 {
 	if (preview_bitmap != NULL) {
 		uint32 *source_bits = (uint32*)tall_copy_of_the_preview_bitmap->Bits();

--- a/addons/AddOns/Blur/Blur.h
+++ b/addons/AddOns/Blur/Blur.h
@@ -106,10 +106,10 @@ public:
 			BlurManipulator(BBitmap*);
 			~BlurManipulator();
 
-BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
 BView*		MakeConfigurationView(const BMessenger& target);
-int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion* =NULL);
-void		Reset(Selection*);
+int32		PreviewBitmap(bool full_quality = FALSE, BRegion* =NULL);
+void		Reset();
 void		SetPreviewBitmap(BBitmap*);
 
 
@@ -126,6 +126,8 @@ void		ChangeSettings(ManipulatorSettings*);
 
 status_t	ReadSettings(BNode*);
 status_t	WriteSettings(BNode*);
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 

--- a/addons/AddOns/Brightness/Brightness.h
+++ b/addons/AddOns/Brightness/Brightness.h
@@ -69,7 +69,7 @@ class BrightnessManipulator : public WindowGUIManipulator {
 
 			BrightnessManipulatorSettings	current_settings;
 
-			Selection	*current_selection;
+			Selection	*selection;
 
 			BBitmap		*source_bitmap;
 			BBitmap		*target_bitmap;
@@ -86,9 +86,9 @@ public:
 			~BrightnessManipulator();
 
 void		MouseDown(BPoint,uint32 buttons,BView*,bool);
-int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion* =NULL);
-BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
-void		Reset(Selection*);
+int32		PreviewBitmap(bool full_quality = FALSE, BRegion* =NULL);
+BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
+void		Reset();
 void		SetPreviewBitmap(BBitmap*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
@@ -98,6 +98,8 @@ ManipulatorSettings*	ReturnSettings();
 BView*		MakeConfigurationView(const BMessenger& target);
 
 void		ChangeSettings(ManipulatorSettings*);
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 

--- a/addons/AddOns/ColorBalance/ColorBalance.cpp
+++ b/addons/AddOns/ColorBalance/ColorBalance.cpp
@@ -39,10 +39,9 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 }
 
 
-
-
 ColorBalanceManipulator::ColorBalanceManipulator(BBitmap *bm)
-		: WindowGUIManipulator()
+		: WindowGUIManipulator(),
+		selection(NULL)
 {
 	preview_bitmap = NULL;
 	copy_of_the_preview_bitmap = NULL;
@@ -65,9 +64,10 @@ ColorBalanceManipulator::~ColorBalanceManipulator()
 	}
 }
 
-BBitmap* ColorBalanceManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* ColorBalanceManipulator::ManipulateBitmap(ManipulatorSettings* set,
+	BBitmap* original, BStatusBar* status_bar)
 {
-	ColorBalanceManipulatorSettings *new_settings = dynamic_cast<ColorBalanceManipulatorSettings*>(set);
+	ColorBalanceManipulatorSettings* new_settings = dynamic_cast<ColorBalanceManipulatorSettings*>(set);
 
 	if (new_settings == NULL)
 		return NULL;
@@ -140,7 +140,8 @@ BBitmap* ColorBalanceManipulator::ManipulateBitmap(ManipulatorSettings *set,BBit
 }
 
 
-int32 ColorBalanceManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRegion *updated_region)
+int32 ColorBalanceManipulator::PreviewBitmap(bool full_quality,
+	BRegion* updated_region)
 {
 	if ((settings == previous_settings) == FALSE) {
 		previous_settings = settings;
@@ -236,7 +237,7 @@ const char*	ColorBalanceManipulator::ReturnName()
 	return B_TRANSLATE("Color balance");
 }
 
-void ColorBalanceManipulator::Reset(Selection*)
+void ColorBalanceManipulator::Reset()
 {
 	if (preview_bitmap != NULL) {
 		uint32 *source_bits = (uint32*)copy_of_the_preview_bitmap->Bits();

--- a/addons/AddOns/ColorBalance/ColorBalance.h
+++ b/addons/AddOns/ColorBalance/ColorBalance.h
@@ -68,15 +68,15 @@ class ColorBalanceManipulator : public WindowGUIManipulator {
 		int32	lowest_allowed_quality;
 		int32	last_used_quality;
 
-
+		Selection*	selection;
 
 public:
 			ColorBalanceManipulator(BBitmap*);
 			~ColorBalanceManipulator();
 
-int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion* =NULL);
-BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
-void		Reset(Selection*);
+int32		PreviewBitmap(bool full_quality = FALSE, BRegion* =NULL);
+BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
+void		Reset();
 void		SetPreviewBitmap(BBitmap*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
@@ -85,6 +85,8 @@ ManipulatorSettings*	ReturnSettings();
 BView*	MakeConfigurationView(const BMessenger& target);
 
 void	ChangeSettings(ManipulatorSettings*);
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 

--- a/addons/AddOns/ColorReducer/Reducer.cpp
+++ b/addons/AddOns/ColorReducer/Reducer.cpp
@@ -54,7 +54,8 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 
 
 ReducerManipulator::ReducerManipulator(BBitmap *bm)
-		: WindowGUIManipulator()
+		: WindowGUIManipulator(),
+		selection(NULL)
 {
 	preview_bitmap = NULL;
 	config_view = NULL;
@@ -73,9 +74,10 @@ ReducerManipulator::~ReducerManipulator()
 }
 
 
-BBitmap* ReducerManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* ReducerManipulator::ManipulateBitmap(ManipulatorSettings* set,
+	BBitmap* original, BStatusBar* status_bar)
 {
-	ReducerManipulatorSettings *new_settings = cast_as(set,ReducerManipulatorSettings);
+	ReducerManipulatorSettings* new_settings = cast_as(set,ReducerManipulatorSettings);
 
 	if (new_settings == NULL)
 		return NULL;
@@ -113,7 +115,8 @@ BBitmap* ReducerManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *
 }
 
 
-int32 ReducerManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRegion *updated_region)
+int32 ReducerManipulator::PreviewBitmap(bool full_quality,
+	BRegion* updated_region)
 {
 	if (settings == previous_settings ) {
 		return 0;
@@ -168,7 +171,7 @@ void ReducerManipulator::SetPreviewBitmap(BBitmap *bm)
 }
 
 
-void ReducerManipulator::Reset(Selection*)
+void ReducerManipulator::Reset()
 {
 	if (copy_of_the_preview_bitmap != NULL) {
 		// memcpy seems to be about 10-15% faster that copying with a loop.

--- a/addons/AddOns/ColorReducer/Reducer.h
+++ b/addons/AddOns/ColorReducer/Reducer.h
@@ -82,15 +82,16 @@ class ReducerManipulator : public WindowGUIManipulator {
 
 void		do_dither(BBitmap*,BBitmap*,const rgb_color *palette,int palette_size,int32 dither_mode);
 
+Selection*	selection;
 
 public:
 			ReducerManipulator(BBitmap*);
 			~ReducerManipulator();
 
 void		MouseDown(BPoint,uint32 buttons,BView*,bool);
-int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion* =NULL);
-BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
-void		Reset(Selection*);
+int32		PreviewBitmap(bool full_quality = FALSE, BRegion* =NULL);
+BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
+void		Reset();
 void		SetPreviewBitmap(BBitmap*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
@@ -100,6 +101,8 @@ ManipulatorSettings*	ReturnSettings();
 BView*		MakeConfigurationView(const BMessenger& target);
 
 void		ChangeSettings(ManipulatorSettings*);
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 
@@ -119,7 +122,7 @@ class ReducerManipulatorView : public WindowGUIManipulatorView {
 		BMenuField		*dither_mode_menu_field;
 		BMenuField		*palette_size_menu_field;
 		BMenuField		*palette_mode_menu_field;
-		
+
 		BStringView		*busy;
 
 public:

--- a/addons/AddOns/ColorSeparator/ColorSeparator.cpp
+++ b/addons/AddOns/ColorSeparator/ColorSeparator.cpp
@@ -51,7 +51,8 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 
 
 ColorSeparatorManipulator::ColorSeparatorManipulator(BBitmap *bm)
-		: WindowGUIManipulator()
+		: WindowGUIManipulator(),
+		selection(NULL)
 {
 	preview_bitmap = NULL;
 	config_view = NULL;
@@ -68,9 +69,10 @@ ColorSeparatorManipulator::~ColorSeparatorManipulator()
 }
 
 
-BBitmap* ColorSeparatorManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* ColorSeparatorManipulator::ManipulateBitmap(ManipulatorSettings* set,
+	BBitmap *original, BStatusBar* status_bar)
 {
-	ColorSeparatorManipulatorSettings *new_settings = cast_as(set,ColorSeparatorManipulatorSettings);
+	ColorSeparatorManipulatorSettings* new_settings = cast_as(set,ColorSeparatorManipulatorSettings);
 
 	if (new_settings == NULL)
 		return NULL;
@@ -98,7 +100,8 @@ BBitmap* ColorSeparatorManipulator::ManipulateBitmap(ManipulatorSettings *set,BB
 	return target_bitmap;
 }
 
-int32 ColorSeparatorManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRegion *updated_region)
+int32 ColorSeparatorManipulator::PreviewBitmap(bool full_quality,
+	BRegion* updated_region)
 {
 	updated_region->Set(preview_bitmap->Bounds());
 
@@ -134,7 +137,7 @@ void ColorSeparatorManipulator::SetPreviewBitmap(BBitmap *bm)
 }
 
 
-void ColorSeparatorManipulator::Reset(Selection*)
+void ColorSeparatorManipulator::Reset()
 {
 	if (copy_of_the_preview_bitmap != NULL) {
 		// memcpy seems to be about 10-15% faster that copying with a loop.

--- a/addons/AddOns/ColorSeparator/ColorSeparator.h
+++ b/addons/AddOns/ColorSeparator/ColorSeparator.h
@@ -68,14 +68,16 @@ class ColorSeparatorManipulator : public WindowGUIManipulator {
 
 void		separate_colors();
 
+Selection*	selection;
+
 public:
 			ColorSeparatorManipulator(BBitmap*);
 			~ColorSeparatorManipulator();
 
 void		MouseDown(BPoint,uint32 buttons,BView*,bool);
-int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion* =NULL);
-BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
-void		Reset(Selection*);
+int32		PreviewBitmap(bool full_quality = FALSE, BRegion* =NULL);
+BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
+void		Reset();
 void		SetPreviewBitmap(BBitmap*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
@@ -85,6 +87,8 @@ ManipulatorSettings*	ReturnSettings();
 BView*		MakeConfigurationView(const BMessenger& target);
 
 void		ChangeSettings(ManipulatorSettings*);
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 

--- a/addons/AddOns/Contrast/Contrast.cpp
+++ b/addons/AddOns/Contrast/Contrast.cpp
@@ -45,7 +45,8 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 
 
 ContrastManipulator::ContrastManipulator(BBitmap *bm)
-		: WindowGUIManipulator()
+		: WindowGUIManipulator(),
+		selection(NULL)
 {
 	preview_bitmap = NULL;
 	config_view = NULL;
@@ -64,9 +65,10 @@ ContrastManipulator::~ContrastManipulator()
 }
 
 
-BBitmap* ContrastManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* ContrastManipulator::ManipulateBitmap(ManipulatorSettings* set,
+	BBitmap* original, BStatusBar* status_bar)
 {
-	ContrastManipulatorSettings *new_settings = dynamic_cast<ContrastManipulatorSettings*>(set);
+	ContrastManipulatorSettings* new_settings = dynamic_cast<ContrastManipulatorSettings*>(set);
 
 	if (new_settings == NULL)
 		return NULL;
@@ -88,7 +90,6 @@ BBitmap* ContrastManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap 
 
 
 	current_resolution = 1;
-	current_selection = selection;
 	current_settings = *new_settings;
 	progress_bar = status_bar;
 	current_average_luminance = CalculateAverageLuminance(source_bitmap);
@@ -98,10 +99,10 @@ BBitmap* ContrastManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap 
 	return target_bitmap;
 }
 
-int32 ContrastManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRegion *updated_region)
+int32 ContrastManipulator::PreviewBitmap(bool full_quality,\
+	BRegion* updated_region)
 {
 	progress_bar = NULL;
-	current_selection = selection;
 	if (settings == previous_settings ) {
 		if ((last_calculated_resolution != highest_available_quality) && (last_calculated_resolution > 0))
 			last_calculated_resolution = max_c(highest_available_quality,floor(last_calculated_resolution/2.0));
@@ -220,7 +221,7 @@ int32 ContrastManipulator::thread_function(int32 thread_number)
 		luminance_values[i] = max_c(0,min_c(255,i * coeff + luminance_factor));
 	}
 
-	if (current_selection->IsEmpty()) {
+	if (selection->IsEmpty()) {
 		// Here handle the whole image.
 		int32 left = target_bitmap->Bounds().left;
 		int32 right = target_bitmap->Bounds().right;
@@ -263,7 +264,7 @@ int32 ContrastManipulator::thread_function(int32 thread_number)
 	}
 	else {
 		// Here handle only those pixels for which selection->ContainsPoint(x,y) is true.
-		BRect rect = current_selection->GetBoundingRect();
+		BRect rect = selection->GetBoundingRect();
 
 		int32 left = rect.left;
 		int32 right = rect.right;
@@ -285,7 +286,7 @@ int32 ContrastManipulator::thread_function(int32 thread_number)
 			int32 y_times_source_bpr = y*source_bpr;
 			int32 y_times_target_bpr = y*target_bpr;
 			for (int32 x=left;x<=right;x+=step) {
-				if (current_selection->ContainsPoint(x,y)) {
+				if (selection->ContainsPoint(x,y)) {
 					color.word = *(source_bits + x + y_times_source_bpr);
 					color.bytes[0] = luminance_values[color.bytes[0]];
 					color.bytes[1] = luminance_values[color.bytes[1]];
@@ -350,7 +351,7 @@ void ContrastManipulator::SetPreviewBitmap(BBitmap *bm)
 }
 
 
-void ContrastManipulator::Reset(Selection*)
+void ContrastManipulator::Reset()
 {
 	if (copy_of_the_preview_bitmap != NULL) {
 		// memcpy seems to be about 10-15% faster that copying with a loop.

--- a/addons/AddOns/Contrast/Contrast.h
+++ b/addons/AddOns/Contrast/Contrast.h
@@ -71,7 +71,7 @@ class ContrastManipulator : public WindowGUIManipulator {
 
 			ContrastManipulatorSettings	current_settings;
 
-			Selection	*current_selection;
+			Selection	*selection;
 
 			BBitmap		*source_bitmap;
 			BBitmap		*target_bitmap;
@@ -90,9 +90,9 @@ public:
 			~ContrastManipulator();
 
 void		MouseDown(BPoint,uint32 buttons,BView*,bool);
-int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion* =NULL);
-BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
-void		Reset(Selection*);
+int32		PreviewBitmap(bool full_quality = FALSE, BRegion* =NULL);
+BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
+void		Reset();
 void		SetPreviewBitmap(BBitmap*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
@@ -102,6 +102,8 @@ ManipulatorSettings*	ReturnSettings();
 BView*		MakeConfigurationView(const BMessenger&);
 
 void		ChangeSettings(ManipulatorSettings*);
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 

--- a/addons/AddOns/ContrastManipulator/ContrastManipulator.cpp
+++ b/addons/AddOns/ContrastManipulator/ContrastManipulator.cpp
@@ -38,7 +38,8 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 
 
 ContrastManipulator::ContrastManipulator(BBitmap*)
-		: Manipulator()
+		: Manipulator(),
+		selection(NULL)
 {
 }
 
@@ -49,7 +50,7 @@ ContrastManipulator::~ContrastManipulator()
 }
 
 
-BBitmap* ContrastManipulator::ManipulateBitmap(BBitmap *original, Selection *selection, BStatusBar*)
+BBitmap* ContrastManipulator::ManipulateBitmap(BBitmap* original, BStatusBar*)
 {
 	uint32 *bits = (uint32*)original->Bits();
 	int32 bits_length = original->BitsLength()/4;

--- a/addons/AddOns/ContrastManipulator/ContrastManipulator.h
+++ b/addons/AddOns/ContrastManipulator/ContrastManipulator.h
@@ -13,14 +13,17 @@
 
 class ContrastManipulator : public Manipulator {
 BBitmap		*target_bitmap;
+Selection*	selection;
 
 public:
 			ContrastManipulator(BBitmap*);
 			~ContrastManipulator();
 
-BBitmap*	ManipulateBitmap(BBitmap*,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap*, BStatusBar*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 #endif

--- a/addons/AddOns/Dispersion/DispersionAddOn.cpp
+++ b/addons/AddOns/Dispersion/DispersionAddOn.cpp
@@ -46,7 +46,8 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 
 
 DispersionManipulator::DispersionManipulator(BBitmap*)
-		: Manipulator()
+		: Manipulator(),
+		selection(NULL)
 {
 }
 
@@ -56,7 +57,7 @@ DispersionManipulator::~DispersionManipulator()
 
 }
 
-BBitmap* DispersionManipulator::ManipulateBitmap(BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* DispersionManipulator::ManipulateBitmap(BBitmap *original, BStatusBar *status_bar)
 {
 	BWindow *status_bar_window = NULL;
 	if (status_bar != NULL)

--- a/addons/AddOns/Dispersion/DispersionAddOn.h
+++ b/addons/AddOns/Dispersion/DispersionAddOn.h
@@ -15,13 +15,17 @@
 #define	MAX_DISPERSION_X	8
 
 class DispersionManipulator : public Manipulator {
+Selection* selection;
+
 public:
 			DispersionManipulator(BBitmap*);
 			~DispersionManipulator();
 
-BBitmap*	ManipulateBitmap(BBitmap*,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap*, BStatusBar*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; }
 };
 
 #endif

--- a/addons/AddOns/EdgeDetector/DetectEdges.cpp
+++ b/addons/AddOns/EdgeDetector/DetectEdges.cpp
@@ -42,7 +42,8 @@ Manipulator* instantiate_add_on(BBitmap*,ManipulatorInformer *i)
 
 
 DetectEdgesManipulator::DetectEdgesManipulator()
-		: Manipulator()
+		: Manipulator(),
+		selection(NULL)
 {
 	processor_count = GetSystemCpuCount();
 }
@@ -53,7 +54,8 @@ DetectEdgesManipulator::~DetectEdgesManipulator()
 }
 
 
-BBitmap* DetectEdgesManipulator::ManipulateBitmap(BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* DetectEdgesManipulator::ManipulateBitmap(BBitmap* original,
+	BStatusBar* status_bar)
 {
 	/*
 		This function will first copy the original and then calculate the effect from the copy
@@ -81,7 +83,6 @@ BBitmap* DetectEdgesManipulator::ManipulateBitmap(BBitmap *original,Selection *s
 	// know what to do.
 	source_bitmap = duplicate;
 	target_bitmap = original;
-	the_selection = selection;
 	progress_bar = status_bar;
 
 	thread_id *threads = new thread_id[processor_count];
@@ -148,7 +149,7 @@ int32 DetectEdgesManipulator::thread_function(int32 thread_number)
 		uint32 word;
 	} color;
 
-	if (the_selection->IsEmpty()) {
+	if (selection->IsEmpty()) {
 		// Here handle the whole image.
 		int32 left = target_bitmap->Bounds().left;
 		int32 right = target_bitmap->Bounds().right;
@@ -248,7 +249,7 @@ int32 DetectEdgesManipulator::thread_function(int32 thread_number)
 	}
 	else {
 		// Here handle only those pixels for which selection->ContainsPoint(x,y) is true.
-		BRect rect = the_selection->GetBoundingRect();
+		BRect rect = selection->GetBoundingRect();
 
 		int32 left = rect.left;
 		int32 right = rect.right;
@@ -265,7 +266,7 @@ int32 DetectEdgesManipulator::thread_function(int32 thread_number)
 		// Loop through all pixels in original.
 		for (int32 y=top;y<=bottom;++y) {
 			for (int32 x=left;x<=right;++x) {
-				if (the_selection->ContainsPoint(x,y)) {
+				if (selection->ContainsPoint(x,y)) {
 					float red = 0;
 					float green = 0;
 					float blue = 0;

--- a/addons/AddOns/EdgeDetector/DetectEdges.h
+++ b/addons/AddOns/EdgeDetector/DetectEdges.h
@@ -15,7 +15,7 @@ class DetectEdgesManipulator : public Manipulator {
 		BBitmap		*source_bitmap;
 		BBitmap		*target_bitmap;
 		BStatusBar	*progress_bar;
-		Selection	*the_selection;
+		Selection	*selection;
 
 static	int32		thread_entry(void*);
 		int32		thread_function(int32);
@@ -25,8 +25,10 @@ public:
 			DetectEdgesManipulator();
 			~DetectEdgesManipulator();
 
-BBitmap*	ManipulateBitmap(BBitmap*,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap*, BStatusBar*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; }
 };
 #endif

--- a/addons/AddOns/Emboss/EmbossAddOn.cpp
+++ b/addons/AddOns/Emboss/EmbossAddOn.cpp
@@ -43,7 +43,8 @@ Manipulator* instantiate_add_on(BBitmap*,ManipulatorInformer *i)
 
 
 EmbossManipulator::EmbossManipulator()
-		: Manipulator()
+		: Manipulator(),
+		selection(NULL)
 {
 }
 
@@ -56,7 +57,8 @@ EmbossManipulator::~EmbossManipulator()
 #define LT (*(spare_bits-spare_bpr-1))
 #define RB (*(spare_bits+spare_bpr+1))
 
-BBitmap* EmbossManipulator::ManipulateBitmap(BBitmap *original,Selection *selection,BStatusBar *progress_view)
+BBitmap* EmbossManipulator::ManipulateBitmap(BBitmap *original,
+	BStatusBar *progress_view)
 {
 	// We may create another bitmap and return it instead of original, but we may
 	// also do the manipulation on the original and return it. We Should send messages

--- a/addons/AddOns/Emboss/EmbossAddOn.h
+++ b/addons/AddOns/Emboss/EmbossAddOn.h
@@ -12,13 +12,16 @@
 #include "Manipulator.h"
 
 class EmbossManipulator : public Manipulator {
+Selection*	selection;
 public:
 			EmbossManipulator();
 			~EmbossManipulator();
 
-BBitmap*	ManipulateBitmap(BBitmap*,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap*, BStatusBar*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 #endif

--- a/addons/AddOns/EnhanceEdges/EnhanceEdges.cpp
+++ b/addons/AddOns/EnhanceEdges/EnhanceEdges.cpp
@@ -42,7 +42,8 @@ Manipulator* instantiate_add_on(BBitmap*,ManipulatorInformer *i)
 
 
 EnhanceEdgesManipulator::EnhanceEdgesManipulator()
-		: Manipulator()
+		: Manipulator(),
+		selection(NULL)
 {
 	processor_count = GetSystemCpuCount();
 }
@@ -53,7 +54,8 @@ EnhanceEdgesManipulator::~EnhanceEdgesManipulator()
 }
 
 
-BBitmap* EnhanceEdgesManipulator::ManipulateBitmap(BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* EnhanceEdgesManipulator::ManipulateBitmap(BBitmap* original,
+	BStatusBar* status_bar)
 {
 	/*
 		This function will first copy the original and then calculate the effect from the copy
@@ -87,7 +89,6 @@ BBitmap* EnhanceEdgesManipulator::ManipulateBitmap(BBitmap *original,Selection *
 	// know what to do.
 	source_bitmap = duplicate;
 	target_bitmap = original;
-	the_selection = selection;
 	progress_bar = status_bar;
 
 	thread_id *threads = new thread_id[processor_count];
@@ -157,7 +158,7 @@ int32 EnhanceEdgesManipulator::thread_function(int32 thread_number)
 		uint32 word;
 	} color;
 
-	if (the_selection->IsEmpty()) {
+	if (selection->IsEmpty()) {
 		// Here handle the whole image.
 		int32 left = target_bitmap->Bounds().left;
 		int32 right = target_bitmap->Bounds().right;
@@ -257,7 +258,7 @@ int32 EnhanceEdgesManipulator::thread_function(int32 thread_number)
 	}
 	else {
 		// Here handle only those pixels for which selection->ContainsPoint(x,y) is true.
-		BRect rect = the_selection->GetBoundingRect();
+		BRect rect = selection->GetBoundingRect();
 
 		int32 left = rect.left;
 		int32 right = rect.right;
@@ -274,7 +275,7 @@ int32 EnhanceEdgesManipulator::thread_function(int32 thread_number)
 		// Loop through all pixels in original.
 		for (int32 y=top;y<=bottom;++y) {
 			for (int32 x=left;x<=right;++x) {
-				if (the_selection->ContainsPoint(x,y)) {
+				if (selection->ContainsPoint(x,y)) {
 					float red = 0;
 					float green = 0;
 					float blue = 0;

--- a/addons/AddOns/EnhanceEdges/EnhanceEdges.h
+++ b/addons/AddOns/EnhanceEdges/EnhanceEdges.h
@@ -15,7 +15,7 @@ class EnhanceEdgesManipulator : public Manipulator {
 		BBitmap		*source_bitmap;
 		BBitmap		*target_bitmap;
 		BStatusBar	*progress_bar;
-		Selection	*the_selection;
+		Selection	*selection;
 
 static	int32		thread_entry(void*);
 		int32		thread_function(int32);
@@ -25,8 +25,10 @@ public:
 			EnhanceEdgesManipulator();
 			~EnhanceEdgesManipulator();
 
-BBitmap*	ManipulateBitmap(BBitmap*,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap*, BStatusBar*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 #endif

--- a/addons/AddOns/GaussianBlur/GaussianBlur.cpp
+++ b/addons/AddOns/GaussianBlur/GaussianBlur.cpp
@@ -47,7 +47,8 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 
 
 GaussianBlurManipulator::GaussianBlurManipulator(BBitmap *bm)
-		: WindowGUIManipulator()
+		: WindowGUIManipulator(),
+		selection(NULL)
 {
 	preview_bitmap = NULL;
 	config_view = NULL;
@@ -75,7 +76,8 @@ GaussianBlurManipulator::~GaussianBlurManipulator()
 }
 
 
-BBitmap* GaussianBlurManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* GaussianBlurManipulator::ManipulateBitmap(ManipulatorSettings* set,
+	BBitmap* original, BStatusBar* status_bar)
 {
 	GaussianBlurManipulatorSettings *new_settings = dynamic_cast<GaussianBlurManipulatorSettings*>(set);
 
@@ -99,17 +101,16 @@ BBitmap* GaussianBlurManipulator::ManipulateBitmap(ManipulatorSettings *set,BBit
 
 
 	current_resolution = 1;
-	current_selection = selection;
 	current_settings = *new_settings;
 	progress_bar = status_bar;
 
 	return target_bitmap;
 }
 
-int32 GaussianBlurManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRegion *updated_region)
+int32 GaussianBlurManipulator::PreviewBitmap(bool full_quality,
+	BRegion* updated_region)
 {
 	progress_bar = NULL;
-	current_selection = selection;
 	if (settings == previous_settings ) {
 		if ((last_calculated_resolution != highest_available_quality) && (last_calculated_resolution > 0))
 			last_calculated_resolution = max_c(highest_available_quality,floor(last_calculated_resolution/2.0));
@@ -127,7 +128,7 @@ int32 GaussianBlurManipulator::PreviewBitmap(Selection *selection,bool full_qual
 	if (last_calculated_resolution > 0) {
 		if (selection->IsEmpty()) {
 			updated_region->Set(preview_bitmap->Bounds());
-			Reset(selection);
+			Reset();
 			ipLibrary->gaussian_blur(preview_bitmap,settings.blur,processor_count);
 		}
 		else {
@@ -220,9 +221,8 @@ void GaussianBlurManipulator::SetPreviewBitmap(BBitmap *bm)
 }
 
 
-void GaussianBlurManipulator::Reset(Selection*)
+void GaussianBlurManipulator::Reset()
 {
-	printf("Reset\n");
 	if (copy_of_the_preview_bitmap != NULL) {
 		// memcpy seems to be about 10-15% faster that copying with a loop.
 		uint32 *source = (uint32*)copy_of_the_preview_bitmap->Bits();

--- a/addons/AddOns/GaussianBlur/GaussianBlur.h
+++ b/addons/AddOns/GaussianBlur/GaussianBlur.h
@@ -71,7 +71,7 @@ class GaussianBlurManipulator : public WindowGUIManipulator {
 
 			GaussianBlurManipulatorSettings	current_settings;
 
-			Selection	*current_selection;
+			Selection	*selection;
 
 			BBitmap		*source_bitmap;
 			BBitmap		*target_bitmap;
@@ -84,9 +84,9 @@ public:
 			~GaussianBlurManipulator();
 
 void		MouseDown(BPoint,uint32 buttons,BView*,bool);
-int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion* =NULL);
-BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
-void		Reset(Selection*);
+int32		PreviewBitmap(bool full_quality = FALSE, BRegion* =NULL);
+BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
+void		Reset();
 void		SetPreviewBitmap(BBitmap*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
@@ -97,6 +97,8 @@ BView*		MakeConfigurationView(const BMessenger& target);
 
 void		ChangeSettings(ManipulatorSettings*);
 ImageProcessingLibrary	*ipLibrary;
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 

--- a/addons/AddOns/Grayscale/GrayscaleAddOn.cpp
+++ b/addons/AddOns/Grayscale/GrayscaleAddOn.cpp
@@ -41,7 +41,8 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 
 
 GrayscaleAddOnManipulator::GrayscaleAddOnManipulator(BBitmap*)
-		: Manipulator()
+		: Manipulator(),
+		selection(NULL)
 {
 }
 
@@ -52,7 +53,8 @@ GrayscaleAddOnManipulator::~GrayscaleAddOnManipulator()
 }
 
 
-BBitmap* GrayscaleAddOnManipulator::ManipulateBitmap(BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* GrayscaleAddOnManipulator::ManipulateBitmap(BBitmap* original,
+	BStatusBar* status_bar)
 {
 	// We may create another bitmap and return it instead of original, but we may
 	// also do the manipulation on the original and return it. We Should send messages

--- a/addons/AddOns/Grayscale/GrayscaleAddOn.h
+++ b/addons/AddOns/Grayscale/GrayscaleAddOn.h
@@ -12,13 +12,16 @@
 #include "Manipulator.h"
 
 class GrayscaleAddOnManipulator : public Manipulator {
+Selection*	selection;
 public:
 			GrayscaleAddOnManipulator(BBitmap*);
 			~GrayscaleAddOnManipulator();
 
-BBitmap*	ManipulateBitmap(BBitmap*,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap*, BStatusBar*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 #endif

--- a/addons/AddOns/Halftone/Halftone.cpp
+++ b/addons/AddOns/Halftone/Halftone.cpp
@@ -41,8 +41,11 @@ Manipulator* instantiate_add_on(BBitmap*,ManipulatorInformer *i)
 
 
 Halftone::Halftone(ManipulatorInformer *i)
-	: Manipulator(), round_dot_size(ROUND_DOT_SIZE), diagonal_line_size(DIAGONAL_LINE_SIZE)
-	, ordered_matrix_size(ORDERED_MATRIX_SIZE)
+	: Manipulator(),
+	round_dot_size(ROUND_DOT_SIZE),
+	diagonal_line_size(DIAGONAL_LINE_SIZE),
+	ordered_matrix_size(ORDERED_MATRIX_SIZE),
+	selection(NULL)
 {
 	informer = i;
 	round_dot_pattern[0][0] = 1;
@@ -179,7 +182,7 @@ Halftone::~Halftone()
 }
 
 
-BBitmap* Halftone::ManipulateBitmap(BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* Halftone::ManipulateBitmap(BBitmap* original, BStatusBar* status_bar)
 {
 	return round_dot_halftone(original,selection,status_bar);
 //	return diagonal_line_halftone(original,selection,status_bar);

--- a/addons/AddOns/Halftone/Halftone.h
+++ b/addons/AddOns/Halftone/Halftone.h
@@ -34,13 +34,16 @@ ManipulatorInformer	*informer;
 	BBitmap*	ordered_dither_halftone(BBitmap*,Selection*,BStatusBar*);
 	BBitmap*	fs_dither_halftone(BBitmap*,Selection*,BStatusBar*);
 	BBitmap*	ncandidate_dither_halftone(BBitmap*,Selection*,BStatusBar*);
+	Selection*	selection;
 
 public:
 			Halftone(ManipulatorInformer*);
 			~Halftone();
 
-BBitmap*	ManipulateBitmap(BBitmap*,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap*, BStatusBar*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 #endif

--- a/addons/AddOns/Interference/Interference.cpp
+++ b/addons/AddOns/Interference/Interference.cpp
@@ -65,7 +65,8 @@ instantiate_add_on(BBitmap* bm, ManipulatorInformer* i)
 
 
 InterferenceManipulator::InterferenceManipulator(BBitmap* bm, ManipulatorInformer* i)
-		: WindowGUIManipulator()
+		: WindowGUIManipulator(),
+		selection(NULL)
 {
 	copy_of_the_preview_bitmap = NULL;
 	preview_bitmap = NULL;
@@ -95,9 +96,10 @@ InterferenceManipulator::~InterferenceManipulator()
 
 
 BBitmap*
-InterferenceManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *original,Selection *selection,BStatusBar *status_bar)
+InterferenceManipulator::ManipulateBitmap(ManipulatorSettings* set,
+	BBitmap* original, BStatusBar* status_bar)
 {
-	InterferenceManipulatorSettings *new_settings = dynamic_cast<InterferenceManipulatorSettings*>(set);
+	InterferenceManipulatorSettings* new_settings = dynamic_cast<InterferenceManipulatorSettings*>(set);
 
 	if (new_settings == NULL)
 		return NULL;
@@ -105,18 +107,19 @@ InterferenceManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *orig
 	if (original == NULL)
 		return NULL;
 
-	MakeInterference(original,new_settings,selection);
+	MakeInterference(original, new_settings);
 
 	return original;
 }
 
 
 int32
-InterferenceManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRegion *updated_region)
+InterferenceManipulator::PreviewBitmap(bool full_quality,
+	BRegion* updated_region)
 {
 	if ((settings == previous_settings) == FALSE) {
 		previous_settings = settings;
-		MakeInterference(preview_bitmap,&previous_settings,selection);
+		MakeInterference(preview_bitmap, &previous_settings);
 		updated_region->Set(selection->GetBoundingRect());
 		return 1;
 	}
@@ -142,13 +145,14 @@ InterferenceManipulator::MouseDown(BPoint point,uint32 buttons,BView*,bool first
 
 
 void
-InterferenceManipulator::MakeInterference(BBitmap *target, InterferenceManipulatorSettings *set, Selection *sel)
+InterferenceManipulator::MakeInterference(BBitmap* target,
+	InterferenceManipulatorSettings* set)
 {
 	BStopWatch watch("Making an interference");
 	uint32 *target_bits = (uint32*)target->Bits();
 	uint32 target_bpr = target->BytesPerRow()/4;
 
-	BRect b = sel->GetBoundingRect();
+	BRect b = selection->GetBoundingRect();
 
 	// the wave lengths are taken as inverse numbers
 	float wl_A = 1.0/set->waveLengthA;
@@ -183,7 +187,7 @@ InterferenceManipulator::MakeInterference(BBitmap *target, InterferenceManipulat
 
 	for (int32 y=b.top;y<=b.bottom;y++) {
 		for (int32 x=b.left;x<=b.right;x++) {
-			if (sel->ContainsPoint(x,y)) {
+			if (selection->ContainsPoint(x,y)) {
 				float dist_A = sqrt(pow(fabs(x-c_A.x),2) + pow(fabs(y-c_A.y),2));
 				float dist_B = sqrt(pow(fabs(x-c_B.x),2) + pow(fabs(y-c_B.y),2));
 
@@ -259,7 +263,7 @@ InterferenceManipulator::ReturnName()
 
 
 void
-InterferenceManipulator::Reset(Selection*)
+InterferenceManipulator::Reset()
 {
 	if (preview_bitmap != NULL) {
 		uint32 *source_bits = (uint32*)copy_of_the_preview_bitmap->Bits();

--- a/addons/AddOns/Interference/Interference.h
+++ b/addons/AddOns/Interference/Interference.h
@@ -85,19 +85,19 @@ class InterferenceManipulator : public WindowGUIManipulator {
 
 	ManipulatorInformer				*informer;
 
-	void		MakeInterference(BBitmap*, InterferenceManipulatorSettings*,
-					Selection*);
+	void		MakeInterference(BBitmap*, InterferenceManipulatorSettings*);
+	Selection*	selection;
 
 public:
 				InterferenceManipulator(BBitmap*, ManipulatorInformer*);
 				~InterferenceManipulator();
 
 	void		MouseDown(BPoint,uint32 buttons, BView*, bool);
-	int32		PreviewBitmap(Selection*, bool full_quality = FALSE,
+	int32		PreviewBitmap(bool full_quality = FALSE,
 					BRegion* = NULL);
 	BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*,
-					Selection*, BStatusBar*);
-	void		Reset(Selection*);
+					BStatusBar*);
+	void		Reset();
 	void		SetPreviewBitmap(BBitmap*);
 	const char*	ReturnHelpString();
 	const char*	ReturnName();
@@ -107,8 +107,9 @@ public:
 	BView*		MakeConfigurationView(const BMessenger& target);
 
 	void		ChangeSettings(ManipulatorSettings*);
+	void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
-
 
 
 class InterferenceManipulatorView : public WindowGUIManipulatorView {

--- a/addons/AddOns/MarbleTexturer/Marble.h
+++ b/addons/AddOns/MarbleTexturer/Marble.h
@@ -17,7 +17,6 @@ class MarbleManipulator : public Manipulator {
 		BBitmap		*source_bitmap;
 		BBitmap		*target_bitmap;
 		BStatusBar	*progress_bar;
-		Selection	*the_selection;
 
 		BBitmap		*spare_copy_bitmap;
 
@@ -28,14 +27,17 @@ static	int32		thread_entry(void*);
 
 		float		marble_amount(float);
 		int			processor_count;
+		Selection*	selection;
 
 public:
 			MarbleManipulator(ManipulatorInformer*);
 			~MarbleManipulator();
 
-BBitmap*	ManipulateBitmap(BBitmap*,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap*, BStatusBar*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 #endif

--- a/addons/AddOns/Negative/NegativeAddOn.cpp
+++ b/addons/AddOns/Negative/NegativeAddOn.cpp
@@ -43,7 +43,8 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 
 
 NegativeAddOnManipulator::NegativeAddOnManipulator(BBitmap*)
-		: Manipulator()
+		: Manipulator(),
+		selection(NULL)
 {
 }
 
@@ -54,7 +55,8 @@ NegativeAddOnManipulator::~NegativeAddOnManipulator()
 }
 
 
-BBitmap* NegativeAddOnManipulator::ManipulateBitmap(BBitmap *original, Selection *selection, BStatusBar *status_bar)
+BBitmap* NegativeAddOnManipulator::ManipulateBitmap(BBitmap* original,
+	BStatusBar* status_bar)
 {
 	BMessage progress_message = BMessage(B_UPDATE_STATUS_BAR);
 	progress_message.AddFloat("delta",0.0);

--- a/addons/AddOns/Negative/NegativeAddOn.h
+++ b/addons/AddOns/Negative/NegativeAddOn.h
@@ -12,13 +12,16 @@
 #include "Manipulator.h"
 
 class NegativeAddOnManipulator : public Manipulator {
+Selection*	selection;
 public:
 			NegativeAddOnManipulator(BBitmap*);
 			~NegativeAddOnManipulator();
 
-BBitmap*	ManipulateBitmap(BBitmap*,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap*, BStatusBar*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 #endif

--- a/addons/AddOns/Oil/OilAddOn.cpp
+++ b/addons/AddOns/Oil/OilAddOn.cpp
@@ -43,7 +43,8 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 
 
 OilManipulator::OilManipulator(BBitmap*)
-		: Manipulator()
+		: Manipulator(),
+		selection(NULL)
 {
 }
 
@@ -53,7 +54,8 @@ OilManipulator::~OilManipulator()
 
 }
 
-BBitmap* OilManipulator::ManipulateBitmap(BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* OilManipulator::ManipulateBitmap(BBitmap* original,
+	BStatusBar* status_bar)
 {
 	BWindow *status_bar_window = NULL;
 	if (status_bar != NULL)

--- a/addons/AddOns/Oil/OilAddOn.h
+++ b/addons/AddOns/Oil/OilAddOn.h
@@ -13,13 +13,16 @@
 
 
 class OilManipulator : public Manipulator {
+Selection*	selection;
 public:
 			OilManipulator(BBitmap*);
 			~OilManipulator();
 
-BBitmap*	ManipulateBitmap(BBitmap*,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap*, BStatusBar*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 #endif

--- a/addons/AddOns/PolarMapper/PolarMapper.cpp
+++ b/addons/AddOns/PolarMapper/PolarMapper.cpp
@@ -45,7 +45,8 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 
 
 PolarMapper::PolarMapper(BBitmap*)
-		: Manipulator()
+		: Manipulator(),
+		selection(NULL)
 {
 }
 
@@ -55,7 +56,8 @@ PolarMapper::~PolarMapper()
 
 }
 
-BBitmap* PolarMapper::ManipulateBitmap(BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* PolarMapper::ManipulateBitmap(BBitmap* original,
+	BStatusBar* status_bar)
 {
 	BWindow *status_bar_window = NULL;
 	if (status_bar != NULL)

--- a/addons/AddOns/PolarMapper/PolarMapper.h
+++ b/addons/AddOns/PolarMapper/PolarMapper.h
@@ -15,13 +15,16 @@
 #define	MAX_DISPERSION_X	8
 
 class PolarMapper : public Manipulator {
+Selection*	selection;
 public:
 			PolarMapper(BBitmap*);
 			~PolarMapper();
 
-BBitmap*	ManipulateBitmap(BBitmap*,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap*, BStatusBar*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 #endif

--- a/addons/AddOns/Saturation/Saturation.h
+++ b/addons/AddOns/Saturation/Saturation.h
@@ -71,7 +71,7 @@ class SaturationManipulator : public WindowGUIManipulator {
 
 			SaturationManipulatorSettings	current_settings;
 
-			Selection	*current_selection;
+			Selection	*selection;
 
 			BBitmap		*source_bitmap;
 			BBitmap		*target_bitmap;
@@ -90,9 +90,9 @@ public:
 			~SaturationManipulator();
 
 void		MouseDown(BPoint,uint32 buttons,BView*,bool);
-int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion* =NULL);
-BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
-void		Reset(Selection*);
+int32		PreviewBitmap(bool full_quality = FALSE, BRegion* =NULL);
+BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
+void		Reset();
 void		SetPreviewBitmap(BBitmap*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
@@ -102,6 +102,8 @@ ManipulatorSettings*	ReturnSettings();
 BView*		MakeConfigurationView(const BMessenger& target);
 
 void		ChangeSettings(ManipulatorSettings*);
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 

--- a/addons/AddOns/Sharpness/Sharpness.h
+++ b/addons/AddOns/Sharpness/Sharpness.h
@@ -78,7 +78,7 @@ class SharpnessManipulator : public WindowGUIManipulator {
 
 			SharpnessManipulatorSettings	current_settings;
 
-			Selection	*current_selection;
+			Selection	*selection;
 
 			BBitmap		*source_bitmap;
 			BBitmap		*target_bitmap;
@@ -98,9 +98,9 @@ public:
 			~SharpnessManipulator();
 
 void		MouseDown(BPoint,uint32 buttons,BView*,bool);
-int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion* =NULL);
-BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
-void		Reset(Selection*);
+int32		PreviewBitmap(bool full_quality = FALSE, BRegion* =NULL);
+BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
+void		Reset();
 void		SetPreviewBitmap(BBitmap*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
@@ -112,6 +112,8 @@ BView*		MakeConfigurationView(const BMessenger& target);
 void		ChangeSettings(ManipulatorSettings*);
 
 ImageProcessingLibrary	*ipLibrary;
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 

--- a/addons/AddOns/Threshold/Threshold.h
+++ b/addons/AddOns/Threshold/Threshold.h
@@ -72,7 +72,7 @@ class ThresholdManipulator : public WindowGUIManipulator {
 
 			ThresholdManipulatorSettings	current_settings;
 
-			Selection	*current_selection;
+			Selection	*selection;
 
 			BBitmap		*source_bitmap;
 			BBitmap		*target_bitmap;
@@ -92,9 +92,9 @@ public:
 			~ThresholdManipulator();
 
 void		MouseDown(BPoint,uint32 buttons,BView*,bool);
-int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion* =NULL);
-BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
-void		Reset(Selection*);
+int32		PreviewBitmap(bool full_quality = FALSE, BRegion* =NULL);
+BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
+void		Reset();
 void		SetPreviewBitmap(BBitmap*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
@@ -107,6 +107,8 @@ void		ChangeSettings(ManipulatorSettings*);
 
 status_t	WriteSettings(BNode *node);
 status_t	ReadSettings(BNode *node);
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 

--- a/addons/AddOns/Twirl/Twirl.cpp
+++ b/addons/AddOns/Twirl/Twirl.cpp
@@ -46,7 +46,8 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 
 
 TwirlManipulator::TwirlManipulator(BBitmap *bm)
-		: WindowGUIManipulator()
+		: WindowGUIManipulator(),
+		selection(NULL)
 {
 	last_calculated_resolution = 8;
 	lowest_available_quality = 8;
@@ -90,9 +91,10 @@ void TwirlManipulator::MouseDown(BPoint point,uint32,BView*,bool first_click)
 }
 
 
-BBitmap* TwirlManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* TwirlManipulator::ManipulateBitmap(ManipulatorSettings* set,
+	BBitmap* original, BStatusBar* status_bar)
 {
-	TwirlManipulatorSettings *new_settings = dynamic_cast<TwirlManipulatorSettings*>(set);
+	TwirlManipulatorSettings* new_settings = dynamic_cast<TwirlManipulatorSettings*>(set);
 
 	if (new_settings == NULL)
 		return NULL;
@@ -286,7 +288,8 @@ BBitmap* TwirlManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *or
 }
 
 
-int32 TwirlManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRegion *updated_region)
+int32 TwirlManipulator::PreviewBitmap(bool full_quality,
+	BRegion* updated_region)
 {
 	if ((settings == previous_settings) == FALSE) {
 		previous_settings = settings;
@@ -449,7 +452,7 @@ void TwirlManipulator::SetPreviewBitmap(BBitmap *bm)
 }
 
 
-void TwirlManipulator::Reset(Selection*)
+void TwirlManipulator::Reset()
 {
 	if (preview_bitmap != NULL) {
 		uint32 *source_bits = (uint32*)copy_of_the_preview_bitmap->Bits();

--- a/addons/AddOns/Twirl/Twirl.h
+++ b/addons/AddOns/Twirl/Twirl.h
@@ -81,15 +81,16 @@ float						*cos_table;
 int32						last_calculated_resolution;
 int32						lowest_available_quality;
 int32						highest_available_quality;
+Selection*					selection;
 
 public:
 			TwirlManipulator(BBitmap*);
 			~TwirlManipulator();
 
 void		MouseDown(BPoint,uint32 buttons,BView*,bool);
-int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion* =NULL);
-BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
-void		Reset(Selection*);
+int32		PreviewBitmap(bool full_quality = FALSE, BRegion* =NULL);
+BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
+void		Reset();
 void		SetPreviewBitmap(BBitmap*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
@@ -98,7 +99,8 @@ ManipulatorSettings*	ReturnSettings();
 
 BView*		MakeConfigurationView(const BMessenger& target);
 void		ChangeSettings(ManipulatorSettings *s);
-
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 class TwirlManipulatorView : public WindowGUIManipulatorView {

--- a/addons/AddOns/Wave/Wave.cpp
+++ b/addons/AddOns/Wave/Wave.cpp
@@ -51,7 +51,8 @@ Manipulator* instantiate_add_on(BBitmap *bm,ManipulatorInformer *i)
 
 
 WaveManipulator::WaveManipulator(BBitmap *bm)
-		: WindowGUIManipulator()
+		: WindowGUIManipulator(),
+		selection(NULL)
 {
 	last_calculated_resolution = 8;
 	lowest_available_quality = 8;
@@ -81,9 +82,10 @@ WaveManipulator::~WaveManipulator()
 }
 
 
-BBitmap* WaveManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* WaveManipulator::ManipulateBitmap(ManipulatorSettings* set,
+	BBitmap* original, BStatusBar* status_bar)
 {
-	WaveManipulatorSettings *new_settings = dynamic_cast<WaveManipulatorSettings*>(set);
+	WaveManipulatorSettings* new_settings = dynamic_cast<WaveManipulatorSettings*>(set);
 
 	if (new_settings == NULL)
 		return NULL;
@@ -366,7 +368,9 @@ BBitmap* WaveManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap *ori
 	return original;
 }
 
-int32 WaveManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRegion *updated_region)
+
+int32
+WaveManipulator::PreviewBitmap(bool full_quality, BRegion* updated_region)
 {
 	if ((settings == previous_settings) == FALSE) {
 		previous_settings = settings;
@@ -930,7 +934,7 @@ void WaveManipulator::SetPreviewBitmap(BBitmap *bm)
 }
 
 
-void WaveManipulator::Reset(Selection*)
+void WaveManipulator::Reset()
 {
 	if (preview_bitmap != NULL) {
 		uint32 *source_bits = (uint32*)copy_of_the_preview_bitmap->Bits();

--- a/addons/AddOns/Wave/Wave.h
+++ b/addons/AddOns/Wave/Wave.h
@@ -85,16 +85,16 @@ int32					last_calculated_resolution;
 int32					lowest_available_quality;
 int32					highest_available_quality;
 
-
+Selection*				selection;
 
 public:
 			WaveManipulator(BBitmap*);
 			~WaveManipulator();
 
 void		MouseDown(BPoint,uint32 buttons,BView*,bool);
-int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion* =NULL);
-BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
-void		Reset(Selection*);
+int32		PreviewBitmap(bool full_quality = FALSE, BRegion* =NULL);
+BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
+void		Reset();
 void		SetPreviewBitmap(BBitmap*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
@@ -104,6 +104,8 @@ ManipulatorSettings*	ReturnSettings();
 BView*		MakeConfigurationView(const BMessenger& target);
 
 void		ChangeSettings(ManipulatorSettings*);
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 

--- a/addons/AddOns/WoodRelief/Wood.cpp
+++ b/addons/AddOns/WoodRelief/Wood.cpp
@@ -44,7 +44,8 @@ Manipulator* instantiate_add_on(BBitmap*,ManipulatorInformer *i)
 
 
 WoodManipulator::WoodManipulator()
-		: Manipulator()
+		: Manipulator(),
+		selection(NULL)
 {
 	processor_count = GetSystemCpuCount();
 }
@@ -55,13 +56,13 @@ WoodManipulator::~WoodManipulator()
 }
 
 
-BBitmap* WoodManipulator::ManipulateBitmap(BBitmap *original,Selection *selection,BStatusBar *status_bar)
+BBitmap* WoodManipulator::ManipulateBitmap(BBitmap* original,
+	BStatusBar* status_bar)
 {
 	BStopWatch watch("PerlinWood");
 
 	source_bitmap = original;
 	target_bitmap = original;
-	the_selection = selection;
 	progress_bar = status_bar;
 
 	thread_id *threads = new thread_id[processor_count];
@@ -131,7 +132,7 @@ int32 WoodManipulator::thread_function(int32 thread_number)
 		uint32 word;
 	} color,color1,color2,color3;
 
-	if (the_selection->IsEmpty()) {
+	if (selection->IsEmpty()) {
 		// Here handle the whole image.
 		float left = target_bitmap->Bounds().left;
 		float right = target_bitmap->Bounds().right;
@@ -204,7 +205,7 @@ int32 WoodManipulator::thread_function(int32 thread_number)
 	}
 	else {
 		// Here handle only those pixels for which selection->ContainsPoint(x,y) is true.
-		BRect rect = the_selection->GetBoundingRect();
+		BRect rect = selection->GetBoundingRect();
 
 		int32 left = rect.left;
 		int32 right = rect.right;
@@ -230,7 +231,7 @@ int32 WoodManipulator::thread_function(int32 thread_number)
 		// Loop through all pixels in original.
 		for (int32 y=top;y<=bottom;++y) {
 			for (int32 x=left;x<=right;++x) {
-				if (the_selection->ContainsPoint(x,y)) {
+				if (selection->ContainsPoint(x,y)) {
 
 					color1.word = *(spare_bits - spare_bpr - 1);
 					color2.word = *(spare_bits + spare_bpr + 1);

--- a/addons/AddOns/WoodRelief/Wood.h
+++ b/addons/AddOns/WoodRelief/Wood.h
@@ -15,7 +15,7 @@ class WoodManipulator : public Manipulator {
 		BBitmap		*source_bitmap;
 		BBitmap		*target_bitmap;
 		BStatusBar	*progress_bar;
-		Selection	*the_selection;
+		Selection	*selection;
 
 		BBitmap		*spare_copy_bitmap;
 
@@ -27,9 +27,11 @@ public:
 			WoodManipulator();
 			~WoodManipulator();
 
-BBitmap*	ManipulateBitmap(BBitmap*,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap*, BStatusBar*);
 const char*	ReturnHelpString();
 const char*	ReturnName();
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 #endif

--- a/artpaint/viewmanipulators/CropManipulator.cpp
+++ b/artpaint/viewmanipulators/CropManipulator.cpp
@@ -37,7 +37,8 @@ using ArtPaint::Interface::NumberControl;
 
 
 CropManipulator::CropManipulator(BBitmap* bm)
-	: WindowGUIManipulator()
+	: WindowGUIManipulator(),
+	selection(NULL)
 {
 	settings = new CropManipulatorSettings();
 	config_view = NULL;
@@ -347,7 +348,7 @@ CropManipulator::Draw(BView* view, float mag_scale)
 
 BBitmap*
 CropManipulator::ManipulateBitmap(ManipulatorSettings* set,
-	BBitmap* original, Selection*, BStatusBar* status_bar)
+	BBitmap* original, BStatusBar* status_bar)
 {
 	CropManipulatorSettings* new_settings =
 		dynamic_cast<CropManipulatorSettings*> (set);
@@ -415,7 +416,7 @@ CropManipulator::ManipulateBitmap(ManipulatorSettings* set,
 
 
 int32
-CropManipulator::PreviewBitmap(Selection* sel, bool, BRegion* updated_region)
+CropManipulator::PreviewBitmap(bool, BRegion* updated_region)
 {
 	int32* target_bits = (int32*)preview_bitmap->Bits();
 	int32* source_bits = (int32*)copy_of_the_preview_bitmap->Bits();
@@ -432,8 +433,8 @@ CropManipulator::PreviewBitmap(Selection* sel, bool, BRegion* updated_region)
 	float height = preview_bitmap->Bounds().Height();
 	float width = preview_bitmap->Bounds().Width();
 
-	if (use_selected == TRUE && sel != NULL && !sel->IsEmpty()) {
-		BRect selection_bounds = sel->GetBoundingRect();
+	if (use_selected == TRUE && selection != NULL && !selection->IsEmpty()) {
+		BRect selection_bounds = selection->GetBoundingRect();
 		SetValues(selection_bounds.left, selection_bounds.Width(),
 			selection_bounds.top, selection_bounds.Height());
 	}
@@ -520,7 +521,7 @@ CropManipulator::SetPreviewBitmap(BBitmap* bm)
 
 
 void
-CropManipulator::Reset(Selection* sel)
+CropManipulator::Reset()
 {
 	BRect bounds = preview_bitmap->Bounds();
 
@@ -743,7 +744,7 @@ CropManipulatorView::MessageReceived(BMessage* message)
 		} break;
 
 		case RESET_CROP: {
-			fManipulator->Reset(NULL);
+			fManipulator->Reset();
 			fTarget.SendMessage(
 				new BMessage(HS_MANIPULATOR_ADJUSTING_FINISHED));
 		} break;

--- a/artpaint/viewmanipulators/CropManipulator.h
+++ b/artpaint/viewmanipulators/CropManipulator.h
@@ -39,8 +39,8 @@ using ArtPaint::Interface::NumberControl;
 
 
 class CropManipulator : public WindowGUIManipulator {
-		BBitmap*	ManipulateBitmap(BBitmap* b, Selection* s, BStatusBar* stb)
-						{ return WindowGUIManipulator::ManipulateBitmap(b, s, stb); }
+		BBitmap*	ManipulateBitmap(BBitmap* b, BStatusBar* stb)
+						{ return WindowGUIManipulator::ManipulateBitmap(b, stb); }
 
 		BBitmap*	target_bitmap;
 		BBitmap*	preview_bitmap;
@@ -67,6 +67,8 @@ class CropManipulator : public WindowGUIManipulator {
 
 		bool		use_selected;
 		bool		lock_aspect;
+
+		Selection*	selection;
 public:
 					CropManipulator(BBitmap*);
 					~CropManipulator();
@@ -76,14 +78,14 @@ public:
 		BRegion		Draw(BView*, float);
 
 		BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap* original,
-					Selection*, BStatusBar*);
+						BStatusBar*);
 		void		SetValues(float, float, float, float);
 
-		int32		PreviewBitmap(Selection*, bool full_quality = false,
+		int32		PreviewBitmap(bool full_quality = false,
 						BRegion* updated_region = NULL);
 
 		BView*		MakeConfigurationView(const BMessenger& target);
-		void		Reset(Selection*);
+		void		Reset();
 		void		SetPreviewBitmap(BBitmap*);
 
 const	char*		ReturnHelpString();
@@ -93,6 +95,9 @@ const	char*		ReturnName();
 
 		void		UseSelected() { use_selected = TRUE; }
 		void		LockAspect(bool lock) { lock_aspect = lock; }
+
+		void		SetSelection(Selection* new_selection)
+						{ selection = new_selection; };
 };
 
 

--- a/artpaint/viewmanipulators/FlipManipulator.cpp
+++ b/artpaint/viewmanipulators/FlipManipulator.cpp
@@ -29,7 +29,8 @@ HorizFlipManipulator::HorizFlipManipulator()
 {
 }
 
-BBitmap* HorizFlipManipulator::ManipulateBitmap(BBitmap *original,Selection*,BStatusBar *status_bar)
+BBitmap* HorizFlipManipulator::ManipulateBitmap(BBitmap* original,
+	BStatusBar* status_bar)
 {
 	int32 height = original->Bounds().IntegerHeight();
 	int32 width = original->Bounds().IntegerWidth();
@@ -66,7 +67,8 @@ VertFlipManipulator::VertFlipManipulator()
 {
 }
 
-BBitmap* VertFlipManipulator::ManipulateBitmap(BBitmap *original,Selection*,BStatusBar *status_bar)
+BBitmap* VertFlipManipulator::ManipulateBitmap(BBitmap* original,
+	BStatusBar* status_bar)
 {
 	int32 height = original->Bounds().IntegerHeight();
 	int32 width = original->Bounds().IntegerWidth();

--- a/artpaint/viewmanipulators/FlipManipulator.h
+++ b/artpaint/viewmanipulators/FlipManipulator.h
@@ -15,18 +15,26 @@ class HorizFlipManipulator : public Manipulator {
 
 public:
 			HorizFlipManipulator();
-BBitmap*	ManipulateBitmap(BBitmap *original,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap* original, BStatusBar*);
 
 const char*	ReturnName();
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
+private:
+Selection*	selection;
 };
 
 class VertFlipManipulator : public Manipulator {
 
 public:
 			VertFlipManipulator();
-BBitmap*	ManipulateBitmap(BBitmap *original,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap* original, BStatusBar*);
 
 const char*	ReturnName();
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
+private:
+Selection*	selection;
 };
 
 

--- a/artpaint/viewmanipulators/FreeTransformManipulator.cpp
+++ b/artpaint/viewmanipulators/FreeTransformManipulator.cpp
@@ -36,7 +36,8 @@
 
 
 FreeTransformManipulator::FreeTransformManipulator(BBitmap *bm)
-	:	WindowGUIManipulator()
+	:	WindowGUIManipulator(),
+	selection(NULL)
 {
 	configuration_view = NULL;
 
@@ -47,7 +48,6 @@ FreeTransformManipulator::FreeTransformManipulator(BBitmap *bm)
 
 	transformation_mode = 0;
 }
-
 
 
 FreeTransformManipulator::~FreeTransformManipulator()
@@ -61,10 +61,9 @@ FreeTransformManipulator::~FreeTransformManipulator()
 }
 
 
-
 BBitmap*
 FreeTransformManipulator::ManipulateBitmap(ManipulatorSettings *set,
-	BBitmap *original, Selection*, BStatusBar *status_bar)
+	BBitmap *original, BStatusBar *status_bar)
 {
 	// TODO: check what's the idea behind this
 
@@ -75,7 +74,7 @@ FreeTransformManipulator::ManipulateBitmap(ManipulatorSettings *set,
 }
 
 
-int32 FreeTransformManipulator::PreviewBitmap(Selection*,bool,BRegion *region)
+int32 FreeTransformManipulator::PreviewBitmap(bool, BRegion *region)
 {
 	if (preview_bitmap == NULL)
 		return 0;
@@ -110,6 +109,7 @@ int32 FreeTransformManipulator::PreviewBitmap(Selection*,bool,BRegion *region)
 
 	return 1;
 }
+
 
 void FreeTransformManipulator::MouseDown(BPoint point,uint32 buttons,BView*,bool first_click)
 {
@@ -146,7 +146,6 @@ void FreeTransformManipulator::MouseDown(BPoint point,uint32 buttons,BView*,bool
 }
 
 
-
 void FreeTransformManipulator::ChangeSettings(ManipulatorSettings *s)
 {
 	// change the values for controls whose values have changed
@@ -156,7 +155,7 @@ void FreeTransformManipulator::ChangeSettings(ManipulatorSettings *s)
 }
 
 
-void FreeTransformManipulator::Reset(Selection*)
+void FreeTransformManipulator::Reset()
 {
 	if (copy_of_the_preview_bitmap != NULL) {
 		// memcpy seems to be about 10-15% faster that copying with loop.
@@ -167,6 +166,7 @@ void FreeTransformManipulator::Reset(Selection*)
 		memcpy(target,source,bits_length);
 	}
 }
+
 
 void FreeTransformManipulator::SetPreviewBitmap(BBitmap *bitmap)
 {

--- a/artpaint/viewmanipulators/FreeTransformManipulator.h
+++ b/artpaint/viewmanipulators/FreeTransformManipulator.h
@@ -77,8 +77,8 @@ float	y_scale_factor;
 
 
 class FreeTransformManipulator : public WindowGUIManipulator {
-	BBitmap*	ManipulateBitmap(BBitmap* b, Selection* s, BStatusBar* stb)
-		{ return WindowGUIManipulator::ManipulateBitmap(b, s, stb); };
+	BBitmap*	ManipulateBitmap(BBitmap* b, BStatusBar* stb)
+		{ return WindowGUIManipulator::ManipulateBitmap(b, stb); };
 
 	BBitmap						*preview_bitmap;
 	BBitmap						*copy_of_the_preview_bitmap;
@@ -89,19 +89,21 @@ class FreeTransformManipulator : public WindowGUIManipulator {
 
 	int32								transformation_mode;
 	BPoint								starting_point;
+	Selection*					selection;
 
 public:
 			FreeTransformManipulator(BBitmap*);
 			~FreeTransformManipulator();
 
-BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap *original,Selection*,BStatusBar*);
-int32		PreviewBitmap(Selection*,bool,BRegion* =NULL);
+BBitmap*		ManipulateBitmap(ManipulatorSettings*, BBitmap* original,
+					BStatusBar*);
+int32			PreviewBitmap(bool, BRegion* =NULL);
 
 void			MouseDown(BPoint,uint32,BView*,bool);
 void			ChangeSettings(ManipulatorSettings* settings);
 
 BView*			MakeConfigurationView(const BMessenger& target);
-void			Reset(Selection*);
+void			Reset();
 void			SetPreviewBitmap(BBitmap*);
 
 const char*		ReturnHelpString();
@@ -109,6 +111,8 @@ const char*		ReturnName();
 
 
 ManipulatorSettings*	ReturnSettings();
+void			SetSelection(Selection* new_selection)
+					{ selection = new_selection; };
 };
 
 

--- a/artpaint/viewmanipulators/GUIManipulator.h
+++ b/artpaint/viewmanipulators/GUIManipulator.h
@@ -36,7 +36,7 @@ enum draw_resolutions {
 
 class GUIManipulator : public Manipulator {
 protected:
-	BBitmap*	ManipulateBitmap(BBitmap *b,Selection*,BStatusBar*) { return b; }
+	BBitmap*	ManipulateBitmap(BBitmap* b, BStatusBar*) { return b; }
 
 public:
 	GUIManipulator() : Manipulator() {}
@@ -44,10 +44,10 @@ public:
 
 
 	virtual	void		MouseDown(BPoint,uint32,BView*,bool) {}
-	virtual	int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion *updated_region=NULL) = 0;
-	virtual	BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*) = 0;
+	virtual	int32		PreviewBitmap(bool full_quality=FALSE,BRegion *updated_region=NULL) = 0;
+	virtual	BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,BStatusBar*) = 0;
 	virtual	BRegion		Draw(BView*,float) { return BRegion(); }
-	virtual	void		Reset(Selection*) = 0;
+	virtual	void		Reset() = 0;
 	virtual	void		SetPreviewBitmap(BBitmap*) = 0;
 	virtual	const	void*		ManipulatorCursor() { return NULL; }
 	virtual	const	char*		ReturnHelpString() = 0;

--- a/artpaint/viewmanipulators/Manipulator.h
+++ b/artpaint/viewmanipulators/Manipulator.h
@@ -53,7 +53,7 @@ public:
 									Manipulator();
 	virtual							~Manipulator() {}
 
-	virtual	BBitmap*				ManipulateBitmap(BBitmap*, Selection*,
+	virtual	BBitmap*				ManipulateBitmap(BBitmap*,
 										BStatusBar*) = 0;
 	virtual	ManipulatorSettings*	ReturnSettings() { return NULL; }
 	virtual	const char*				ReturnName() = 0;
@@ -63,6 +63,8 @@ public:
 										{ return fSystemClockSpeed; }
 	int								GetSystemCpuCount()
 										{ return fCpuCount; }
+	virtual void					SetSelection(Selection* new_selection) = 0;
+
 protected:
 			BBitmap*				DuplicateBitmap(BBitmap* source,
 										int32 inset = 0,

--- a/artpaint/viewmanipulators/Rotate90Manipulator.cpp
+++ b/artpaint/viewmanipulators/Rotate90Manipulator.cpp
@@ -27,7 +27,8 @@ Rotate90ClockwiseManipulator::Rotate90ClockwiseManipulator()
 {
 }
 
-BBitmap* Rotate90ClockwiseManipulator::ManipulateBitmap(BBitmap *original,Selection*,BStatusBar *status_bar)
+BBitmap* Rotate90ClockwiseManipulator::ManipulateBitmap(BBitmap* original,
+	BStatusBar* status_bar)
 {
 	// create a new bitmap that is as wide as the original is high
 	BRect new_bounds(0,0,original->Bounds().Height(),original->Bounds().Width());
@@ -66,7 +67,8 @@ Rotate90CounterclockwiseManipulator::Rotate90CounterclockwiseManipulator()
 }
 
 
-BBitmap* Rotate90CounterclockwiseManipulator::ManipulateBitmap(BBitmap *original,Selection*,BStatusBar *status_bar)
+BBitmap* Rotate90CounterclockwiseManipulator::ManipulateBitmap(BBitmap* original,
+	BStatusBar* status_bar)
 {
 	// create a new bitmap that is as wide as the original is high
 	BRect new_bounds(0,0,original->Bounds().Height(),original->Bounds().Width());

--- a/artpaint/viewmanipulators/Rotate90Manipulator.h
+++ b/artpaint/viewmanipulators/Rotate90Manipulator.h
@@ -15,20 +15,25 @@ class Rotate90ClockwiseManipulator : public Manipulator {
 
 public:
 			Rotate90ClockwiseManipulator();
-BBitmap*	ManipulateBitmap(BBitmap *original,Selection*,BStatusBar*);
+BBitmap*	ManipulateBitmap(BBitmap* original, BStatusBar*);
 
 const char*	ReturnName();
-
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 private:
+Selection*	selection;
 };
 
 class Rotate90CounterclockwiseManipulator : public Manipulator {
 
 public:
 			Rotate90CounterclockwiseManipulator();
-BBitmap*	ManipulateBitmap(BBitmap *original,Selection*,BStatusBar*);
-
+BBitmap*	ManipulateBitmap(BBitmap* original, BStatusBar*);
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 const char*	ReturnName();
+private:
+Selection*	selection;
 };
 
 

--- a/artpaint/viewmanipulators/RotationManipulator.cpp
+++ b/artpaint/viewmanipulators/RotationManipulator.cpp
@@ -42,7 +42,8 @@
 
 
 RotationManipulator::RotationManipulator(BBitmap* bitmap)
-	:	WindowGUIManipulator()
+	:	WindowGUIManipulator(),
+	selection(NULL)
 {
 	settings = new RotationManipulatorSettings();
 	config_view = NULL;
@@ -213,7 +214,7 @@ RotationManipulator::MouseDown(BPoint point, uint32 buttons, BView*, bool first_
 
 BBitmap*
 RotationManipulator::ManipulateBitmap(ManipulatorSettings* set, BBitmap* original,
-	Selection* selection, BStatusBar* status_bar)
+	BStatusBar* status_bar)
 {
 	// Here move the contents of the original-bitmap to the new_bitmap,
 	// rotated by s->angle around s->origin.
@@ -456,7 +457,7 @@ RotationManipulator::ManipulateBitmap(ManipulatorSettings* set, BBitmap* origina
 
 
 int32
-RotationManipulator::PreviewBitmap(Selection* selection, bool full_quality,
+RotationManipulator::PreviewBitmap(bool full_quality,
 	BRegion* updated_region)
 {
 	// First decide the resolution of the bitmap
@@ -582,7 +583,7 @@ RotationManipulator::PreviewBitmap(Selection* selection, bool full_quality,
 
 
 void
-RotationManipulator::Reset(Selection* selection)
+RotationManipulator::Reset()
 {
 	selection->RotateTo(settings->origo, 0);
 	settings->angle = 0;

--- a/artpaint/viewmanipulators/RotationManipulator.h
+++ b/artpaint/viewmanipulators/RotationManipulator.h
@@ -39,27 +39,28 @@ public:
 	-180˚ and +180. Negative angles are clockwise and positive counterclockwise.
 */
 class RotationManipulator: public WindowGUIManipulator {
-	BBitmap*	ManipulateBitmap(BBitmap* b, Selection* s, BStatusBar* stb)
-	{ return WindowGUIManipulator::ManipulateBitmap(b, s, stb); }
+	BBitmap*	ManipulateBitmap(BBitmap* b, BStatusBar* stb)
+	{ return WindowGUIManipulator::ManipulateBitmap(b, stb); }
 
-	BBitmap	*copy_of_the_preview_bitmap;
-	BBitmap	*preview_bitmap;
+	BBitmap* 	copy_of_the_preview_bitmap;
+	BBitmap* 	preview_bitmap;
 
+	float		previous_angle;
+	float		starting_angle;
+	BPoint		previous_origo;
+	int32		last_calculated_resolution;
+	int32		lowest_available_quality;
+	int32		highest_available_quality;
 
-	float	previous_angle;
-	float	starting_angle;
-	BPoint	previous_origo;
-	int32	last_calculated_resolution;
-	int32	lowest_available_quality;
-	int32	highest_available_quality;
+	RotationManipulatorSettings*			settings;
 
-	RotationManipulatorSettings				*settings;
+	HSPolygon*								view_polygon;
 
-	HSPolygon								*view_polygon;
+	RotationManipulatorConfigurationView*	config_view;
 
-	RotationManipulatorConfigurationView	*config_view;
+	bool		move_origo;
 
-	bool	move_origo;
+	Selection*	selection;
 
 public:
 	RotationManipulator(BBitmap*);
@@ -67,13 +68,13 @@ public:
 
 	void		SetPreviewBitmap(BBitmap*);
 
-	BRegion		Draw(BView*,float);
-	void		MouseDown(BPoint,uint32,BView*,bool);
+	BRegion		Draw(BView*, float);
+	void		MouseDown(BPoint, uint32, BView*, bool);
 
-	BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
-	int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion *updated_region=NULL);
-	void			Reset(Selection*);
-
+	BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
+	int32		PreviewBitmap(bool full_quality = FALSE,
+					BRegion* updated_region = NULL);
+	void		Reset();
 
 	const char*	ReturnHelpString();
 	const char*	ReturnName();
@@ -84,8 +85,10 @@ public:
 
 	const	void*			ManipulatorCursor() { return HS_ROTATION_CURSOR; }
 
-
 	void		SetAngle(float);
+
+	void		SetSelection(Selection* new_selection)
+					{ selection = new_selection; };
 };
 
 

--- a/artpaint/viewmanipulators/ScaleManipulator.cpp
+++ b/artpaint/viewmanipulators/ScaleManipulator.cpp
@@ -42,7 +42,8 @@ using ArtPaint::Interface::NumberControl;
 
 
 ScaleManipulator::ScaleManipulator(BBitmap *bm)
-	:	WindowGUIManipulator()
+	:	WindowGUIManipulator(),
+	selection(NULL)
 {
 	configuration_view = NULL;
 	settings = new ScaleManipulatorSettings();
@@ -68,7 +69,7 @@ ScaleManipulator::~ScaleManipulator()
 
 
 BBitmap* ScaleManipulator::ManipulateBitmap(ManipulatorSettings *set,
-	BBitmap *original, Selection*, BStatusBar *status_bar)
+	BBitmap *original, BStatusBar *status_bar)
 {
 	ScaleManipulatorSettings *new_settings =
 			dynamic_cast<ScaleManipulatorSettings*> (set);
@@ -251,7 +252,7 @@ BBitmap* ScaleManipulator::ManipulateBitmap(ManipulatorSettings *set,
 }
 
 
-int32 ScaleManipulator::PreviewBitmap(Selection*,bool,BRegion *region)
+int32 ScaleManipulator::PreviewBitmap(bool, BRegion* region)
 {
 	if (preview_bitmap == NULL)
 		return 0;
@@ -336,7 +337,7 @@ ScaleManipulator::SetValues(float width, float height)
 
 
 void
-ScaleManipulator::Reset(Selection*)
+ScaleManipulator::Reset()
 {
 	if (copy_of_the_preview_bitmap) {
 		// memcpy seems to be about 10-15% faster that copying with a loop.

--- a/artpaint/viewmanipulators/ScaleManipulator.h
+++ b/artpaint/viewmanipulators/ScaleManipulator.h
@@ -63,40 +63,41 @@ public:
 
 
 class ScaleManipulator : public WindowGUIManipulator {
-	BBitmap*	ManipulateBitmap(BBitmap* b, Selection* s, BStatusBar* stb)
-	{ return WindowGUIManipulator::ManipulateBitmap(b, s, stb); }
+	BBitmap*	ManipulateBitmap(BBitmap* b, BStatusBar* stb)
+	{ return WindowGUIManipulator::ManipulateBitmap(b, stb); }
 
-	BBitmap						*preview_bitmap;
-	BBitmap						*copy_of_the_preview_bitmap;
+	BBitmap*	preview_bitmap;
+	BBitmap*	copy_of_the_preview_bitmap;
 
 	ScaleManipulatorView		*configuration_view;
 	ScaleManipulatorSettings	*settings;
 
+	float		original_width;
+	float		original_height;
 
-
-	float						original_width;
-	float						original_height;
+	Selection*	selection;
 
 public:
 	ScaleManipulator(BBitmap*);
 	~ScaleManipulator();
 
-	BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap *original,
-					Selection*,BStatusBar*);
-	int32		PreviewBitmap(Selection*,bool,BRegion* =NULL);
+	BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap *original,
+					BStatusBar*);
+	int32		PreviewBitmap(bool, BRegion* =NULL);
 
-	void		MouseDown(BPoint,uint32,BView*,bool);
-	void		SetValues(float,float);
+	void		MouseDown(BPoint, uint32, BView*, bool);
+	void		SetValues(float, float);
 
 	BView*		MakeConfigurationView(const BMessenger& target);
-	void		Reset(Selection*);
+	void		Reset();
 	void		SetPreviewBitmap(BBitmap*);
 
 	const	char*	ReturnHelpString();
 	const	char*	ReturnName();
 
-
 	ManipulatorSettings*	ReturnSettings();
+	void		SetSelection(Selection* new_selection)
+					{ selection = new_selection; };
 };
 
 

--- a/artpaint/viewmanipulators/TextManipulator.cpp
+++ b/artpaint/viewmanipulators/TextManipulator.cpp
@@ -56,7 +56,8 @@ using ArtPaint::Interface::NumberSliderControl;
 
 
 TextManipulator::TextManipulator(BBitmap *bm)
-	:	WindowGUIManipulator()
+	:	WindowGUIManipulator(),
+	selection(NULL)
 {
 	preview_bitmap = NULL;
 	copy_of_the_preview_bitmap = NULL;
@@ -113,7 +114,7 @@ BRegion TextManipulator::Draw(BView *view,float)
 
 
 BBitmap* TextManipulator::ManipulateBitmap(ManipulatorSettings *set,
-	BBitmap *original, Selection *selection, BStatusBar*)
+	BBitmap *original, BStatusBar*)
 {
 	TextManipulatorSettings *new_settings = dynamic_cast<TextManipulatorSettings*> (set);
 
@@ -220,7 +221,7 @@ BBitmap* TextManipulator::ManipulateBitmap(ManipulatorSettings *set,
 
 
 
-int32 TextManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRegion *updated_region)
+int32 TextManipulator::PreviewBitmap(bool full_quality,BRegion *updated_region)
 {
 	// First decide the resolution of the bitmap
 	if (previous_settings == fSettings) {
@@ -435,7 +436,7 @@ void TextManipulator::SetPreviewBitmap(BBitmap *bm)
 
 
 void
-TextManipulator::Reset(Selection*)
+TextManipulator::Reset()
 {
 	if (copy_of_the_preview_bitmap) {
 		uint32 *target_bits = (uint32*)preview_bitmap->Bits();

--- a/artpaint/viewmanipulators/TextManipulator.h
+++ b/artpaint/viewmanipulators/TextManipulator.h
@@ -57,8 +57,8 @@ public:
 
 
 class TextManipulator : public WindowGUIManipulator {
-	BBitmap*	ManipulateBitmap(BBitmap* b, Selection* s, BStatusBar* stb)
-	{ return WindowGUIManipulator::ManipulateBitmap(b, s, stb); }
+	BBitmap*	ManipulateBitmap(BBitmap* b, BStatusBar* stb)
+	{ return WindowGUIManipulator::ManipulateBitmap(b, stb); }
 
 	BBitmap	*preview_bitmap;
 	BBitmap	*copy_of_the_preview_bitmap;
@@ -74,17 +74,19 @@ class TextManipulator : public WindowGUIManipulator {
 	int32	last_used_quality;
 	int32	lowest_allowed_quality;
 
+	Selection*	selection;
 public:
 	TextManipulator(BBitmap*);
 	~TextManipulator();
 
-	BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
-	int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion *updated_region=NULL);
+	BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
+	int32		PreviewBitmap(bool full_quality = FALSE,
+					BRegion *updated_region = NULL);
 	BView*		MakeConfigurationView(const BMessenger& target);
 
 	void		MouseDown(BPoint,uint32,BView*,bool);
 	BRegion		Draw(BView*,float);
-	void		Reset(Selection*);
+	void		Reset();
 	void		SetPreviewBitmap(BBitmap*);
 	const	char*	ReturnHelpString();
 	const	char*	ReturnName();
@@ -96,6 +98,9 @@ public:
 
 	status_t	Save(BMessage& settings) const;
 	status_t	Restore(const BMessage& settings);
+
+	void		SetSelection(Selection* new_selection)
+					{ selection = new_selection; };
 };
 
 

--- a/artpaint/viewmanipulators/TranslationManipulator.cpp
+++ b/artpaint/viewmanipulators/TranslationManipulator.cpp
@@ -37,7 +37,8 @@ using ArtPaint::Interface::NumberControl;
 
 TranslationManipulator::TranslationManipulator(BBitmap* bm)
 	: WindowGUIManipulator(),
-	copy_of_the_preview_bitmap(NULL)
+	copy_of_the_preview_bitmap(NULL),
+	selection(NULL)
 {
 	preview_bitmap = bm;
 	if (preview_bitmap != NULL)
@@ -84,7 +85,7 @@ TranslationManipulator::MouseDown(BPoint point, uint32, BView*, bool first)
 
 BBitmap*
 TranslationManipulator::ManipulateBitmap(ManipulatorSettings* set,
-	BBitmap* original, Selection* selection, BStatusBar* status_bar)
+	BBitmap* original, BStatusBar* status_bar)
 {
 	TranslationManipulatorSettings *new_settings = cast_as(set,
 		TranslationManipulatorSettings);
@@ -212,7 +213,7 @@ TranslationManipulator::ManipulateBitmap(ManipulatorSettings* set,
 
 
 int32
-TranslationManipulator::PreviewBitmap(Selection* selection, bool full_quality,
+TranslationManipulator::PreviewBitmap(bool full_quality,
 	BRegion* updated_region)
 {
 	if (preview_bitmap == NULL || copy_of_the_preview_bitmap == NULL)
@@ -401,9 +402,9 @@ TranslationManipulator::ReturnSettings()
 
 
 void
-TranslationManipulator::Reset(Selection* sel)
+TranslationManipulator::Reset()
 {
-	sel->Translate(int32(-settings->x_translation),
+	selection->Translate(int32(-settings->x_translation),
 		int32(-settings->y_translation));
 	settings->x_translation = 0;
 	settings->y_translation = 0;

--- a/artpaint/viewmanipulators/TranslationManipulator.h
+++ b/artpaint/viewmanipulators/TranslationManipulator.h
@@ -28,38 +28,41 @@ using ArtPaint::Interface::NumberControl;
 
 
 class TranslationManipulator : public WindowGUIManipulator {
-	BBitmap*	ManipulateBitmap(BBitmap* b, Selection* s, BStatusBar* stb)
-	{ return WindowGUIManipulator::ManipulateBitmap(b, s, stb); }
+	BBitmap*	ManipulateBitmap(BBitmap* b, BStatusBar* stb)
+	{ return WindowGUIManipulator::ManipulateBitmap(b, stb); }
 
-	BBitmap	*preview_bitmap;
-	BBitmap	*copy_of_the_preview_bitmap;
+	BBitmap*	preview_bitmap;
+	BBitmap*	copy_of_the_preview_bitmap;
 
-	int32	previous_x_translation;
-	int32	previous_y_translation;
+	int32		previous_x_translation;
+	int32		previous_y_translation;
 
-	BPoint	previous_point;
+	BPoint		previous_point;
 
-	BRect	uncleared_rect;
+	BRect		uncleared_rect;
 
-	TranslationManipulatorSettings	*settings;
-	TranslationManipulatorView		*config_view;
+	TranslationManipulatorSettings*	settings;
+	TranslationManipulatorView*		config_view;
 
+	int32		last_calculated_resolution;
+	int32		lowest_available_quality;
+	int32		highest_available_quality;
 
-	int32	last_calculated_resolution;
-	int32	lowest_available_quality;
-	int32	highest_available_quality;
+	Selection*	selection;
 
 public:
 	TranslationManipulator(BBitmap*);
 	~TranslationManipulator();
 
-	void			MouseDown(BPoint,uint32,BView*,bool);
+	void			MouseDown(BPoint, uint32, BView*, bool);
 
-	BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap *original,Selection*,BStatusBar*);
-	int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion *updated_region=NULL);
-	BView*		MakeConfigurationView(const BMessenger& target);
+	BBitmap*		ManipulateBitmap(ManipulatorSettings*, BBitmap *original,
+						BStatusBar*);
+	int32			PreviewBitmap(bool full_quality = FALSE,
+						BRegion* updated_region = NULL);
+	BView*			MakeConfigurationView(const BMessenger& target);
 	void			SetPreviewBitmap(BBitmap*);
-	void			Reset(Selection*);
+	void			Reset();
 
 	const	char*	ReturnName();
 	const	char*	ReturnHelpString();
@@ -67,7 +70,9 @@ public:
 	const	void*	ManipulatorCursor() { return HS_TRANSLATION_CURSOR; }
 
 	ManipulatorSettings*	ReturnSettings();
-	void		SetValues(float,float);
+	void			SetValues(float, float);
+	void			SetSelection(Selection* new_selection)
+						{ selection = new_selection; };
 };
 
 

--- a/artpaint/viewmanipulators/TransparencyManipulator.cpp
+++ b/artpaint/viewmanipulators/TransparencyManipulator.cpp
@@ -29,19 +29,20 @@
 
 
 TransparencyManipulator::TransparencyManipulator(BBitmap *bm)
-	: WindowGUIManipulator()
-	, ImageAdapter()
-	, preview_bitmap(NULL)
-	, copy_of_the_preview_bitmap(NULL)
-	, preview_layer(NULL)
-	, transparency(0)
-	, last_calculated_resolution(0)
-	, lowest_available_quality(0)
-	, highest_available_quality(0)
-	, previous_transparency_change(0.0)
-	, original_transparency_coefficient(0.0)
-	, settings(NULL)
-	, config_view(NULL)
+	: WindowGUIManipulator(),
+	ImageAdapter(),
+	preview_bitmap(NULL),
+	copy_of_the_preview_bitmap(NULL),
+	preview_layer(NULL),
+	transparency(0),
+	last_calculated_resolution(0),
+	lowest_available_quality(0),
+	highest_available_quality(0),
+	previous_transparency_change(0.0),
+	original_transparency_coefficient(0.0),
+	settings(NULL),
+	config_view(NULL),
+	selection(NULL)
 {
 	if (bm) {
 		preview_bitmap = bm;
@@ -64,14 +65,14 @@ TransparencyManipulator::~TransparencyManipulator()
 
 BBitmap*
 TransparencyManipulator::ManipulateBitmap(ManipulatorSettings* set,
-	BBitmap* original, Selection* selection, BStatusBar* status_bar)
+	BBitmap* original, BStatusBar* status_bar)
 {
 	return NULL;
 }
 
 
 int32
-TransparencyManipulator::PreviewBitmap(Selection* selection, bool full_quality,
+TransparencyManipulator::PreviewBitmap(bool full_quality,
 	BRegion* updated_region)
 {
 	// First decide the resolution of the bitmap
@@ -131,7 +132,7 @@ TransparencyManipulator::SetTransparency(float change)
 
 
 void
-TransparencyManipulator::Reset(Selection*)
+TransparencyManipulator::Reset()
 {
 	if (image && image->ContainsLayer(preview_layer)) {
 		preview_layer->SetTransparency(original_transparency_coefficient);

--- a/artpaint/viewmanipulators/TransparencyManipulator.h
+++ b/artpaint/viewmanipulators/TransparencyManipulator.h
@@ -34,8 +34,8 @@ class TransparencyManipulatorView;
 
 
 class TransparencyManipulator : public WindowGUIManipulator, public ImageAdapter {
-	BBitmap*	ManipulateBitmap(BBitmap* b, Selection* s, BStatusBar* stb)
-		{ return WindowGUIManipulator::ManipulateBitmap(b, s, stb); }
+	BBitmap*	ManipulateBitmap(BBitmap* b, BStatusBar* stb)
+		{ return WindowGUIManipulator::ManipulateBitmap(b, stb); }
 
 BBitmap				*preview_bitmap;
 BBitmap				*copy_of_the_preview_bitmap;
@@ -51,20 +51,21 @@ float				previous_transparency_change;
 float				original_transparency_coefficient;
 
 
-
 TransparencyManipulatorSettings	*settings;
 TransparencyManipulatorView		*config_view;
+
+	Selection*	selection;
 
 public:
 			TransparencyManipulator(BBitmap*);
 			~TransparencyManipulator();
 
-BBitmap*	ManipulateBitmap(ManipulatorSettings*,BBitmap*,Selection*,BStatusBar*);
-int32		PreviewBitmap(Selection*,bool full_quality=FALSE,BRegion *updated_region=NULL);
+BBitmap*	ManipulateBitmap(ManipulatorSettings*, BBitmap*, BStatusBar*);
+int32		PreviewBitmap(bool full_quality = FALSE,
+				BRegion* updated_region = NULL);
 BView*		MakeConfigurationView(const BMessenger& target);
 
-
-void		Reset(Selection*);
+void		Reset();
 void		SetPreviewBitmap(BBitmap*);
 
 const	char*	ReturnHelpString();
@@ -74,6 +75,8 @@ void		SetTransparency(float);
 
 ManipulatorSettings*	ReturnSettings();
 
+void		SetSelection(Selection* new_selection)
+				{ selection = new_selection; };
 };
 
 

--- a/artpaint/viewmanipulators/WindowGUIManipulator.h
+++ b/artpaint/viewmanipulators/WindowGUIManipulator.h
@@ -23,6 +23,7 @@ public:
 	virtual					~WindowGUIManipulator() {}
 
 	virtual	BView*			MakeConfigurationView(const BMessenger& target) = 0;
+	virtual	void			SetSelection(Selection* new_selection) = 0;
 };
 
 


### PR DESCRIPTION
Refactored so that each GUI manipulator has a class member called "selection" that holds the current selection when the manipulator is instantiated. This is instead of passing in the selection only when the bitmap is actually manipulated, because the selection should never change during a manipulation. It allows other functions in the manipulator to access the selection, for example if we wanted to draw a transform box around the transform region, or set the rotation pivot to the center of the selection.

This is a relatively large code change but there should be no functionality changed - I tried to test the different manipulators but if you could test the different manipulators to see if they behave no worse than before I'd appreciate it.  

I tried to minimize stylistic changes.