### PR TITLE
SelectorTool: make sure to clear bitmap for ellipse selections

### DIFF
--- a/artpaint/tools/SelectorTool.cpp
+++ b/artpaint/tools/SelectorTool.cpp
@@ -375,6 +375,7 @@ SelectorTool::UseTool(ImageView* view, uint32 buttons, BPoint point,
 				new BBitmap(
 					view->ReturnImage()->ReturnActiveBitmap()->Bounds(),
 					B_RGBA32);
+			memset(draw_map->Bits(), 0x00, draw_map->BitsLength());
 			// We use a fill-tool to select the area:
 			BitmapDrawer* drawer = new BitmapDrawer(draw_map);
 			drawer->DrawEllipse(new_rect, 0xFFFFFFFF, TRUE, FALSE);


### PR DESCRIPTION
Zero out bitmap before drawing into it - feels obvious now!

Fixes #382 