### PR TITLE
RotationManipulator: when selection is set, set origin to center point

### DIFF
--- a/artpaint/viewmanipulators/RotationManipulator.cpp
+++ b/artpaint/viewmanipulators/RotationManipulator.cpp
@@ -634,6 +634,19 @@ RotationManipulator::ReturnName()
 }
 
 
+void
+RotationManipulator::SetSelection(Selection* new_selection)
+{
+	selection = new_selection;
+	if (selection != NULL && selection->IsEmpty() == false) {
+		BRect bounds = selection->GetBoundingRect();
+
+		settings->origo.x = (bounds.right + bounds.left) / 2;
+		settings->origo.y = (bounds.bottom + bounds.top) / 2;
+	}
+}
+
+
 // #pragma mark -- RotationManipulatorConfigurationView
 
 

--- a/artpaint/viewmanipulators/RotationManipulator.h
+++ b/artpaint/viewmanipulators/RotationManipulator.h
@@ -87,8 +87,7 @@ public:
 
 	void		SetAngle(float);
 
-	void		SetSelection(Selection* new_selection)
-					{ selection = new_selection; };
+	void		SetSelection(Selection* new_selection);
 };
 
 


### PR DESCRIPTION
Fixes #378 