### PR TITLE
ImageView: properly cancel manipulators when interrupted

### DIFF
--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -894,6 +894,7 @@ ImageView::MessageReceived(BMessage* message)
 					the_image->Render();
 					manipulated_layers = HS_MANIPULATE_NO_LAYER;
 					Invalidate();
+					start_thread(MANIPULATOR_FINISHER_THREAD);
 				}
 			}
 			cursor_mode = NORMAL_CURSOR_MODE;
@@ -2382,11 +2383,12 @@ bool
 ImageView::PostponeMessageAndFinishManipulator()
 {
 	if (fManipulator) {
+		manipulator_finishing_message = Window()->DetachCurrentMessage();
+
 		BMessage message(HS_MANIPULATOR_FINISHED);
-		message.AddBool("status", true);
+		message.AddBool("status", false);
 		Window()->PostMessage(&message, this);
 
-		manipulator_finishing_message = Window()->DetachCurrentMessage();
 		return true;
 	}
 	return false;


### PR DESCRIPTION
When a manipulator is active (includes Add-Ons), and another manipulator is started, the previous behavior was to execute the changes of the active manipulator. This new behavior cancels the previous manipulator before starting the new manipulator. For example, if a user chooses "translate" and begins moving a selection, and then chooses "rotate", the previous behavior acted as if "Ok" was clicked, and now it acts as if "Cancel" was clicked.

Part of #282 