### PR TITLE
ImageView: don't send mouse click through when panning.

### DIFF
--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -981,23 +981,24 @@ ImageView::MouseDown(BPoint view_point)
 
 			SetCursor();
 			release_sem(mouse_mutex);
-		}
-		if (gui_manipulator != NULL)
-			start_thread(MANIPULATOR_MOUSE_THREAD);
-		else if (fManipulator == NULL) {
-			if (buttons & B_SECONDARY_MOUSE_BUTTON) {
-				BMenuItem* item =
-					ToolManager::Instance().
-						ToolPopUpMenu()->Go(ConvertToScreen(view_point));
-				if (item != NULL) {
-					ToolManager::Instance().ChangeTool(item->Command());
-					SetCursor();	// If the tool changes, the cursor should change too.
-				}
-				release_sem(mouse_mutex);
+		} else {
+			if (gui_manipulator != NULL)
+				start_thread(MANIPULATOR_MOUSE_THREAD);
+			else if (fManipulator == NULL) {
+				if (buttons & B_SECONDARY_MOUSE_BUTTON) {
+					BMenuItem* item =
+						ToolManager::Instance().
+							ToolPopUpMenu()->Go(ConvertToScreen(view_point));
+					if (item != NULL) {
+						ToolManager::Instance().ChangeTool(item->Command());
+						SetCursor();	// If the tool changes, the cursor should change too.
+					}
+					release_sem(mouse_mutex);
+				} else
+					start_thread(PAINTER_THREAD);
 			} else
-				start_thread(PAINTER_THREAD);
-		} else
-			release_sem(mouse_mutex);
+				release_sem(mouse_mutex);
+		}
 	} else {
 		SetCursor();
 		if (fManipulator == NULL) {


### PR DESCRIPTION
Fixes #421 

... well, this prevents unwanted magic wand selections, and getting into a bad state with the intelligent scissors. 

However, note that it's not possible to pan *while* you are making an 'intelligent scissors' selection. The reason is because only one operation can "own" the mouse at a time, and so once you start a selection, you can't interrupt it to pan. It's like if you are drawing a selection rectangle and you try to pan, it won't work.  