### PR TITLE
ImageView: improve mouse zoom

### DIFF
--- a/artpaint/paintwindow/MagnificationView.cpp
+++ b/artpaint/paintwindow/MagnificationView.cpp
@@ -90,7 +90,7 @@ MagnificationView::MagnificationView()
 	BFont font;
 
 	char string[256];
-	sprintf(string,"%s: %.1f%%", B_TRANSLATE("Zoom"), 1600.0);
+	sprintf(string,"%s: %.0f%%", B_TRANSLATE("Zoom"), 1600.0);
 
 	fMagStringView = new MagStringView("magStringView", string);
 
@@ -139,7 +139,7 @@ void
 MagnificationView::SetMagnificationLevel(float magLevel)
 {
 	char string[256];
-	sprintf(string, "%s: %.1f%%", B_TRANSLATE("Zoom"),
+	sprintf(string, "%s: %.0f%%", B_TRANSLATE("Zoom"),
 		100.0 * magLevel);
 	fMagStringView->SetText(string);
 }


### PR DESCRIPTION
- below 100%, zoom tries to hit exact values
- removed decimal from Zoom as it's unnecessary
- fixed mouse zoom so it'll actually hit 1600% now
- fixed bug where +/- zoom buttons were not reflective of current zoom (i.e. if the user mouse-zoomed to 150% and then hit the + button, the zoom wouldn't go to 200%, it would go to whatever the last zoom level was before mouse-zooming)

Addresses #352, maybe fixes it? You can always hit the exact % above 100 by pressing +/- to get to the next nearest zoom level