### PR TITLE
CropManipulator: use ScaleUtilities::MoveGrabbers to save some code

### DIFF
--- a/artpaint/viewmanipulators/CropManipulator.h
+++ b/artpaint/viewmanipulators/CropManipulator.h
@@ -54,7 +54,7 @@ class CropManipulator : public WindowGUIManipulator {
 		float		previous_top;
 		float		previous_bottom;
 
-		float 		last_x, last_y;
+		BPoint		previous_point;
 
 		CropManipulatorSettings* 	settings;
 		CropManipulatorView*		config_view;


### PR DESCRIPTION
- removed duplicate code for moving grabbers that is shared between scale manipulators and crop

no functional change; crop should behave exactly as before.

I should probably share the drawing code between scale and crop too one of these days...