### PR TITLE
EraserTool: Anti-alias edge of eraser

### DIFF
--- a/artpaint/application/PixelOperations.h
+++ b/artpaint/application/PixelOperations.h
@@ -724,14 +724,37 @@ inline uint32 src_out_fixed(uint32 dst, uint32 src)
 	if (result_alpha == 0)
 		return 0;
 
-	// r-rgb * r-a = s-rgb * s-a * (1 - d-a)
+	// r-rgb * r-a = s-rgb * (1 - d-a)
 
-	result_rgba.bytes[0] = (src_rgba.bytes[0] * src_alpha * inv_dst_alpha) /
-		result_alpha;
-	result_rgba.bytes[1] = (src_rgba.bytes[1] * src_alpha * inv_dst_alpha) /
-		result_alpha;
-	result_rgba.bytes[2] = (src_rgba.bytes[2] * src_alpha * inv_dst_alpha) /
-		result_alpha;
+	result_rgba.bytes[0] = src_rgba.bytes[0];
+	result_rgba.bytes[1] = src_rgba.bytes[1];
+	result_rgba.bytes[2] = src_rgba.bytes[2];
+	result_rgba.bytes[3] = result_alpha;
+
+	return result_rgba.word;
+}
+
+
+inline uint32 dst_out_fixed(uint32 dst, uint32 src)
+{
+	union color_conversion src_rgba, dst_rgba, result_rgba;
+
+	src_rgba.word = src;
+	dst_rgba.word = dst;
+
+	uint8 src_alpha = src_rgba.bytes[3];
+	uint8 dst_alpha = dst_rgba.bytes[3];
+
+	uint32 inv_src_alpha = 255 - src_alpha;
+	uint32 result_alpha = (inv_src_alpha * dst_alpha) / 255;
+	if (result_alpha == 0)
+		return 0;
+
+	// r-rgb * r-a = s-rgb * (1 - d-a)
+
+	result_rgba.bytes[0] = dst_rgba.bytes[0];
+	result_rgba.bytes[1] = dst_rgba.bytes[1];
+	result_rgba.bytes[2] = dst_rgba.bytes[2];
 	result_rgba.bytes[3] = result_alpha;
 
 	return result_rgba.word;

--- a/artpaint/tools/EraserTool.cpp
+++ b/artpaint/tools/EraserTool.cpp
@@ -61,7 +61,7 @@ EraserTool::UseTool(ImageView *view, uint32 buttons, BPoint point, BPoint)
 	// here we first get the necessary data from view
 	// and then start drawing while mousebutton is held down
 
-	uint32 (*composite_func)(uint32, uint32) = src_out_fixed;
+	uint32 (*composite_func)(uint32, uint32) = dst_out_fixed;
 
 	// Wait for the last_updated_region to become empty
 	while (LastUpdatedRect().IsValid())
@@ -87,7 +87,7 @@ EraserTool::UseTool(ImageView *view, uint32 buttons, BPoint point, BPoint)
 	background.bytes[0] = 0xFF;
 	background.bytes[1] = 0xFF;
 	background.bytes[2] = 0xFF;
-	background.bytes[3] = 0x00;
+	background.bytes[3] = 0xFF;
 
 
 	if (fToolSettings.mode == HS_ERASE_TO_BACKGROUND_MODE) {


### PR DESCRIPTION
This is something that's been bugging me for a while - the edge of the erased area is not anti-aliased.  This isn't just a personal preference, it's a bug fix to the compositing - now it'll work either way, if we decide to add a checkbox for antialiasing at some point.  This fix is also needed for the Eraser portion of #176, to support soft-edged erasers.

  
