### PR TITLE
PaintWindow: gray out recent items that don't exist on disk

### DIFF
--- a/artpaint/paintwindow/PaintWindow.cpp
+++ b/artpaint/paintwindow/PaintWindow.cpp
@@ -2167,6 +2167,8 @@ PaintWindow::_AddRecentMenuItems(BMenu* menu, const StringList* list)
 				message, 0, 0, this, path.Path());
 			menu->AddItem(item);
 			item->SetTarget(be_app);
+			BEntry entry(&ref, true);
+			item->SetEnabled(entry.Exists());
 		}
 	}
 }


### PR DESCRIPTION
Fixes #461