### PR TITLE
LayerWindow: forward keypresses to canvas

### DIFF
--- a/artpaint/layers/LayerWindow.cpp
+++ b/artpaint/layers/LayerWindow.cpp
@@ -332,6 +332,17 @@ LayerWindow::MessageReceived(BMessage *message)
 						image_window->PostMessage(message, image_view);
 				}
 			} break;
+		case B_KEY_DOWN:
+		case B_UNMAPPED_KEY_DOWN:
+			if (active_layer != NULL && active_layer->IsActive()) {
+				BView *image_view = (BView*)active_layer->GetImageView();
+				BWindow *image_window = image_view->Window();
+
+				if (image_window && active_layer->IsActive()) {
+					image_window->Activate();
+					image_window->PostMessage(message);
+				}
+			} break;
 		default:
 			BWindow::MessageReceived(message);
 			break;


### PR DESCRIPTION
if key is pressed in layer window, activate image window and post the message to it.

Maybe fixes part of #403 ?  Only from the Layer window so far. 