### PR TITLE
BitmapUtilities: make ConvertToMask only output exactly 1 or 0 alpha

### DIFF
--- a/artpaint/Utilities/BitmapUtilities.cpp
+++ b/artpaint/Utilities/BitmapUtilities.cpp
@@ -152,7 +152,11 @@ BitmapUtilities::ConvertToMask(BBitmap *inBitmap, uint8 color)
 	for (int32 y = 0; y < out_map->Bounds().IntegerHeight() + 1; y++) {
 		for (int32 x = 0; x < out_map->Bounds().IntegerWidth() + 1; x++) {
 			c.word = *(in_bits + x + y * in_bpr);
-			float alpha = (float)c.bytes[3] / 255.;
+			// revert this change when the rest of ArtPaint understands
+			// selections with alpha
+			float alpha = 0;
+			if (c.bytes[3] > 0x00)
+				alpha = 1;
 
 			*(out_bits + x + y * out_bpr) = (uint8)((float)color * alpha);
 		}


### PR DESCRIPTION
This fixes #479, but this change should be reverted when #363 is fixed.

I figured it out. It's not a bug, it's a feature!  The "select all non-transparent" uses the layer alpha to cut out the pieces that are transparent.  In my case here, the circle is not fully opaque, and so the resulting selection map is not fully opaque. We decide if something is selected or not based on whether it's exactly 0 or not. 

we need #363 to handle this properly and so for now/this release it's safest to just make "select all non-transparent" just take any non-opaque pixel.  