### PR TITLE
ImageView: remove context menu for right-click

### DIFF
--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -1046,17 +1046,7 @@ ImageView::MouseDown(BPoint view_point)
 			if (gui_manipulator != NULL)
 				start_thread(MANIPULATOR_MOUSE_THREAD);
 			else if (fManipulator == NULL) {
-				if (buttons & B_SECONDARY_MOUSE_BUTTON) {
-					BMenuItem* item =
-						ToolManager::Instance().
-							ToolPopUpMenu()->Go(ConvertToScreen(view_point));
-					if (item != NULL) {
-						ToolManager::Instance().ChangeTool(item->Command());
-						SetCursor();	// If the tool changes, the cursor should change too.
-					}
-					release_sem(mouse_mutex);
-				} else
-					start_thread(PAINTER_THREAD);
+				start_thread(PAINTER_THREAD);
 			} else
 				release_sem(mouse_mutex);
 		}

--- a/artpaint/tools/AirBrushTool.cpp
+++ b/artpaint/tools/AirBrushTool.cpp
@@ -85,7 +85,11 @@ AirBrushTool::UseTool(ImageView *view, uint32 buttons, BPoint point, BPoint)
 		return NULL;
 	}
 
-	rgb_color c = ((PaintApplication*)be_app)->Color(true);
+	bool use_fg_color = true;
+	if (buttons == B_SECONDARY_MOUSE_BUTTON)
+		use_fg_color = false;
+
+	rgb_color c = ((PaintApplication*)be_app)->Color(use_fg_color);
 	uint32 target_color = RGBColorToBGRA(c);
 
 	union color_conversion clear_color;

--- a/artpaint/tools/BrushTool.cpp
+++ b/artpaint/tools/BrushTool.cpp
@@ -119,8 +119,12 @@ BrushTool::UseTool(ImageView *view, uint32 buttons, BPoint point, BPoint viewPoi
 
 	union color_conversion new_color;
 
+	bool use_fg_color = true;
+	if (buttons == B_SECONDARY_MOUSE_BUTTON)
+		use_fg_color = false;
+
 	new_color.word =
-		RGBColorToBGRA(((PaintApplication*)be_app)->Color(true));
+		RGBColorToBGRA(((PaintApplication*)be_app)->Color(use_fg_color));
 
 	union color_conversion clear_color;
 	clear_color.word = new_color.word;

--- a/artpaint/tools/EllipseTool.cpp
+++ b/artpaint/tools/EllipseTool.cpp
@@ -77,7 +77,11 @@ EllipseTool::UseTool(ImageView *view, uint32 buttons, BPoint point, BPoint)
 		old_mode = view->DrawingMode();
 		view->SetDrawingMode(B_OP_INVERT);
 		window->Unlock();
-		rgb_color c = ((PaintApplication*)be_app)->Color(true);
+		bool use_fg_color = true;
+		if (buttons == B_SECONDARY_MOUSE_BUTTON)
+			use_fg_color = false;
+
+		rgb_color c = ((PaintApplication*)be_app)->Color(use_fg_color);
 		original_point = point;
 		bitmap_rect = BRect(point,point);
 		old_rect = new_rect = view->convertBitmapRectToView(bitmap_rect);

--- a/artpaint/tools/FillTool.cpp
+++ b/artpaint/tools/FillTool.cpp
@@ -126,7 +126,11 @@ FillTool::NormalFill(ImageView* view, uint32 buttons, BPoint start, Selection* s
 	bitmap_bounds.OffsetTo(BPoint(0,0));
 
 	// Get the color for the fill.
-	rgb_color c = ((PaintApplication*)be_app)->Color(TRUE);
+	bool use_fg_color = true;
+	if (buttons == B_SECONDARY_MOUSE_BUTTON)
+		use_fg_color = false;
+
+	rgb_color c = ((PaintApplication*)be_app)->Color(use_fg_color);
 	uint32 color = RGBColorToBGRA(c);
 
 	// Get the old color.

--- a/artpaint/tools/FreeLineTool.cpp
+++ b/artpaint/tools/FreeLineTool.cpp
@@ -130,7 +130,11 @@ FreeLineTool::UseTool(ImageView* view, uint32 buttons, BPoint point, BPoint)
 	if ((diameter%2) == 0)
 		diameter++;
 
-	new_color = ((PaintApplication*)be_app)->Color(true);
+	bool use_fg_color = true;
+	if (buttons == B_SECONDARY_MOUSE_BUTTON)
+		use_fg_color = false;
+
+	new_color = ((PaintApplication*)be_app)->Color(use_fg_color);
 	new_color_bgra = RGBColorToBGRA(new_color);
 	if (diameter != 1)
 		drawer->DrawCircle(prev_point, diameter / 2, new_color_bgra,
@@ -171,7 +175,11 @@ FreeLineTool::UseTool(ImageView* view, uint32 buttons, BPoint point, BPoint)
 //				set_mouse_speed(original_mouse_speed);
 //			}
 			// first set the color
-			new_color = ((PaintApplication*)be_app)->Color(true);
+			bool use_fg_color = true;
+			if (buttons == B_SECONDARY_MOUSE_BUTTON)
+				use_fg_color = false;
+
+			new_color = ((PaintApplication*)be_app)->Color(use_fg_color);
 			new_color_bgra = RGBColorToBGRA(new_color);
 
 			diameter = fToolSettings.size;

--- a/artpaint/tools/HairyBrushTool.cpp
+++ b/artpaint/tools/HairyBrushTool.cpp
@@ -102,7 +102,11 @@ HairyBrushTool::UseTool(ImageView *view, uint32 buttons, BPoint point, BPoint)
 	float color_randomnessx2 = color_randomness * 2.0;
 	float initial_color_amount = GetCurrentValue(CONTINUITY_OPTION) / 10.0;
 	float color_amount_randomness = 4;
-	rgb_color color =  ((PaintApplication*)be_app)->Color(true);
+	bool use_fg_color = true;
+	if (buttons == B_SECONDARY_MOUSE_BUTTON)
+		use_fg_color = false;
+
+	rgb_color color =  ((PaintApplication*)be_app)->Color(use_fg_color);
 	int32 hair_count = GetCurrentValue(SIZE_OPTION);
 
 	float *color_amount_array = new float[hair_count];
@@ -116,7 +120,11 @@ HairyBrushTool::UseTool(ImageView *view, uint32 buttons, BPoint point, BPoint)
 			color_amount_randomness +
 			random() % 1000 / 1000.0 * color_amount_randomness * 2.0;
 
-		color_array[i] = ((PaintApplication*)be_app)->Color(true);
+		bool use_fg_color = true;
+		if (buttons == B_SECONDARY_MOUSE_BUTTON)
+			use_fg_color = false;
+
+		color_array[i] = ((PaintApplication*)be_app)->Color(use_fg_color);
 		red = color_array[i].red;
 		green = color_array[i].green;
 		blue = color_array[i].blue;

--- a/artpaint/tools/RectangleTool.cpp
+++ b/artpaint/tools/RectangleTool.cpp
@@ -88,7 +88,11 @@ RectangleTool::UseTool(ImageView *view, uint32 buttons, BPoint point,
 		old_mode = view->DrawingMode();
 		view->SetDrawingMode(B_OP_INVERT);
 		window->Unlock();
-		rgb_color c = ((PaintApplication*)be_app)->Color(true);
+		bool use_fg_color = true;
+		if (buttons == B_SECONDARY_MOUSE_BUTTON)
+			use_fg_color = false;
+
+		rgb_color c = ((PaintApplication*)be_app)->Color(use_fg_color);
 		original_point = point;
 		bitmap_rect = BRect(point,point);
 		old_rect = new_rect = view->convertBitmapRectToView(bitmap_rect);

--- a/artpaint/tools/StraightLineTool.cpp
+++ b/artpaint/tools/StraightLineTool.cpp
@@ -97,7 +97,11 @@ StraightLineTool::UseTool(ImageView* view, uint32 buttons, BPoint point,
 		rgb_color old_color = view->HighColor();
 		window->Unlock();
 		original_point = point;
-		rgb_color c = ((PaintApplication*)be_app)->Color(true);
+		bool use_fg_color = true;
+		if (buttons == B_SECONDARY_MOUSE_BUTTON)
+			use_fg_color = false;
+
+		rgb_color c = ((PaintApplication*)be_app)->Color(use_fg_color);
 
 		prev_view_point = original_view_point = view_point;
 		bitmap_rect = BRect(point.x, point.y -


### PR DESCRIPTION
In all the color-based drawing tools, right-click draws with the bg color.

No change to Blur, Transparency, Eraser, Color Selector, or Selection Tool in this commit.

This is part of #266.