### PR TITLE
Transform selections: remove ellipsis from names, disable/enable menu items

### DIFF
--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -1853,9 +1853,9 @@ ImageView::ManipulatorFinisherThread()
 
 	try {
 		BString manipName = fManipulator->ReturnName();
-		if (manipName == B_TRANSLATE("Translate selection" B_UTF8_ELLIPSIS) ||
-			manipName == B_TRANSLATE("Rotate selection" B_UTF8_ELLIPSIS) ||
-			manipName == B_TRANSLATE("Scale selection" B_UTF8_ELLIPSIS)) {
+		if (manipName == B_TRANSLATE("Translate selection") ||
+			manipName == B_TRANSLATE("Rotate selection") ||
+			manipName == B_TRANSLATE("Scale selection")) {
 			// Add selection-change to the undo-queue.
 			if (!(*undo_queue->ReturnSelectionData() ==
 				*selection->ReturnSelectionData())) {

--- a/artpaint/paintwindow/PaintWindow.cpp
+++ b/artpaint/paintwindow/PaintWindow.cpp
@@ -507,6 +507,33 @@ PaintWindow::MenusBeginning()
 		else
 			item->SetEnabled(true);
 
+
+		item = fMenubar->FindItem(B_TRANSLATE("Selection"));
+		BMenu *selectionMenu = item->Submenu();
+
+		item = selectionMenu->FindItem(B_TRANSLATE("Rotate" B_UTF8_ELLIPSIS));
+		if (item != NULL) {
+			if (fImageView->GetSelection()->IsEmpty())
+				item->SetEnabled(false);
+			else
+				item->SetEnabled(true);
+		}
+
+		item = selectionMenu->FindItem(B_TRANSLATE("Translate" B_UTF8_ELLIPSIS));
+		if (item != NULL) {
+			if (fImageView->GetSelection()->IsEmpty())
+				item->SetEnabled(false);
+			else
+				item->SetEnabled(true);
+		}
+
+		item = selectionMenu->FindItem(B_TRANSLATE("Scale" B_UTF8_ELLIPSIS));
+		if (item != NULL) {
+			if (fImageView->GetSelection()->IsEmpty())
+				item->SetEnabled(false);
+			else
+				item->SetEnabled(true);
+		}
 	}
 
 	if ((fImageEntry.InitCheck() == B_OK) && (fCurrentHandler != 0)) {

--- a/artpaint/viewmanipulators/RotationManipulator.cpp
+++ b/artpaint/viewmanipulators/RotationManipulator.cpp
@@ -649,9 +649,9 @@ const char*
 RotationManipulator::ReturnName()
 {
 	if (transform_selection_only == true)
-		return B_TRANSLATE("Rotate selection" B_UTF8_ELLIPSIS);
+		return B_TRANSLATE("Rotate selection");
 
-	return B_TRANSLATE("Rotate" B_UTF8_ELLIPSIS);
+	return B_TRANSLATE("Rotate");
 }
 
 

--- a/artpaint/viewmanipulators/ScaleManipulator.cpp
+++ b/artpaint/viewmanipulators/ScaleManipulator.cpp
@@ -723,9 +723,9 @@ const char*
 ScaleManipulator::ReturnName()
 {
 	if (transform_selection_only == true)
-		return B_TRANSLATE("Scale selection" B_UTF8_ELLIPSIS);
+		return B_TRANSLATE("Scale selection");
 
-	return B_TRANSLATE("Scale" B_UTF8_ELLIPSIS);
+	return B_TRANSLATE("Scale");
 }
 
 

--- a/artpaint/viewmanipulators/TranslationManipulator.cpp
+++ b/artpaint/viewmanipulators/TranslationManipulator.cpp
@@ -491,9 +491,9 @@ const char*
 TranslationManipulator::ReturnName()
 {
 	if (transform_selection_only == true)
-		return B_TRANSLATE("Translate selection" B_UTF8_ELLIPSIS);
+		return B_TRANSLATE("Translate selection");
 
-	return B_TRANSLATE("Translate" B_UTF8_ELLIPSIS);
+	return B_TRANSLATE("Translate");
 }
 
 


### PR DESCRIPTION
Removed ellipsis from the ReturnName() functions for the manipulators.

When there's no selection, disable the menu items!  Forgot about this in the last PR.