### PR TITLE
LayerWindow: add ability to undo/redo layer 'meta-data' changes

### DIFF
--- a/artpaint/application/UndoEvent.cpp
+++ b/artpaint/application/UndoEvent.cpp
@@ -30,6 +30,7 @@ UndoEvent::UndoEvent(const BString& name, const BBitmap*)
 	previous_event = NULL;
 
 	selection_data = NULL;
+	layer_data = NULL;
 }
 
 
@@ -44,6 +45,8 @@ UndoEvent::~UndoEvent()
 	delete[] actions;
 
 	delete selection_data;
+
+	delete layer_data;
 }
 
 
@@ -101,4 +104,16 @@ void UndoEvent::SetSelectionData(const SelectionData *s)
 {
 	delete selection_data;
 	selection_data = new SelectionData(s);
+}
+
+
+void
+UndoEvent::SetLayerData(Layer* src_layer)
+{
+	layer_data = new Layer(BRect(0, 0, 1, 1), src_layer->Id(), NULL);
+
+	layer_data->SetName(src_layer->ReturnLayerName());
+	layer_data->SetVisibility(src_layer->IsVisible());
+	layer_data->SetTransparency(src_layer->GetOldTransparency());
+	layer_data->SetBlendMode(src_layer->GetBlendMode());
 }

--- a/artpaint/application/UndoEvent.h
+++ b/artpaint/application/UndoEvent.h
@@ -14,6 +14,8 @@
 
 
 #include "UndoAction.h"
+#include "Layer.h"
+
 
 class UndoQueue;
 class SelectionData;
@@ -35,6 +37,8 @@ friend 	class		UndoQueue;
 
 	SelectionData	*selection_data;
 
+		Layer*		layer_data;
+
 public:
 		UndoEvent(const BString& name, const BBitmap *thumbnail);
 		~UndoEvent();
@@ -48,12 +52,14 @@ int32			ActionCount();
 void			SetQueue(UndoQueue *q) { queue = q; }
 bool			IsEmpty();
 
-
 BString			ReturnName() { return event_name; }
 BBitmap*		ReturnThumbnail() { return thumbnail_image; }
 
 SelectionData*	ReturnSelectionData() { return selection_data; }
 void			SetSelectionData(const SelectionData*);
+
+void			SetLayerData(Layer*);
+Layer*			ReturnLayerData() { return layer_data; }
 };
 
 #endif

--- a/artpaint/application/UndoQueue.cpp
+++ b/artpaint/application/UndoQueue.cpp
@@ -536,3 +536,15 @@ UndoQueue::SetSelectionData(const SelectionData *s)
 	delete selection_data;
 	selection_data = new SelectionData(s);
 }
+
+
+void
+UndoQueue::SetLayerData(Layer* src_layer)
+{
+	layer_data = new Layer(BRect(0, 0, 1, 1), src_layer->Id(), NULL);
+
+	layer_data->SetName(src_layer->ReturnLayerName());
+	layer_data->SetVisibility(src_layer->IsVisible());
+	layer_data->SetTransparency(src_layer->GetTransparency());
+	layer_data->SetBlendMode(src_layer->GetBlendMode());
+}

--- a/artpaint/application/UndoQueue.h
+++ b/artpaint/application/UndoQueue.h
@@ -51,7 +51,8 @@ const	char*		ReturnUndoEventName();
 const	char*		ReturnRedoEventName();
 
 
-SelectionData		*selection_data;
+SelectionData*		selection_data;
+Layer*				layer_data;
 
 public:
 			UndoQueue(BMenuItem*,BMenuItem*,ImageView*);
@@ -91,6 +92,9 @@ SelectionData*	ReturnSelectionData() { return selection_data; }
 void	SetSelectionData(const SelectionData*);
 
 bool		IsEmpty() { return (ReturnUndoEventName() == NULL); }
+
+void			SetLayerData(Layer*);
+Layer*			ReturnLayerData() { return layer_data; }
 };
 
 #endif

--- a/artpaint/controls/NumberSliderControl.cpp
+++ b/artpaint/controls/NumberSliderControl.cpp
@@ -109,8 +109,7 @@ NumberSliderControl::MessageReceived(BMessage* message)
 			BString value;
 			value << numValue;
 			fNumberControl->SetText(value.String());
-			if (fContinuous)
-				_SendMessage(numValue, true);
+			_SendMessage(numValue, fContinuous);
 		}	break;
 
 		case kSliderModificationFinished: {

--- a/artpaint/layers/Layer.cpp
+++ b/artpaint/layers/Layer.cpp
@@ -115,7 +115,7 @@ Layer::AddToImage(Image* im)
 
 
 void
-Layer::SetTransparency(float coefficient)
+Layer::SetTransparency(float coefficient, bool update_old)
 {
 	transparency_coefficient = coefficient;
 	for (int i = 0; i < 256; ++i) {
@@ -125,6 +125,9 @@ Layer::SetTransparency(float coefficient)
 		a *= 32768;
 		fixed_alpha_table[i] = (uint32)a;
 	}
+
+	if (update_old == true)
+		old_transparency_coefficient = transparency_coefficient;
 }
 
 
@@ -294,6 +297,11 @@ Layer::SetVisibility(bool visible)
 {
 	fLayerVisible = visible;
 	fLayerView->SetVisibility(visible);
+	if (fLayerView->LockLooper() == true) {
+		fLayerView->Draw(fLayerView->Bounds());
+		fLayerView->Invalidate();
+		fLayerView->UnlockLooper();
+	}
 }
 
 
@@ -602,6 +610,14 @@ Layer::writeLayer(BFile& file, int32 compressionMethod)
 	written_bytes += file.Write(&marker,sizeof(int32));
 
 	return written_bytes;
+}
+
+
+void
+Layer::SetName(const char* name)
+{
+	BString new_name(name);
+	fLayerName = new_name.String();
 }
 
 

--- a/artpaint/layers/Layer.h
+++ b/artpaint/layers/Layer.h
@@ -108,16 +108,20 @@ public:
 									ImageView* imageView, int32 newId);
 			int64				writeLayer(BFile& file, int32 compressionMethod);
 
-			void				SetName(const char* c) { fLayerName = c; }
-			const char*			ReturnLayerName() const { return fLayerName; }
+			void				SetName(const char* name);
+			const char*			ReturnLayerName() const { return fLayerName.String(); }
 
 			const uint32*		ReturnFixedAlphaTable() const {
 									return fixed_alpha_table;
 								}
 
-			void				SetTransparency(float coefficient);
+			void				SetTransparency(float coefficient,
+									bool update_old = TRUE);
 			float				GetTransparency() const {
 									return transparency_coefficient;
+								}
+			float				GetOldTransparency() const {
+									return old_transparency_coefficient;
 								}
 
 			Layer*				ReturnUpperLayer();
@@ -169,6 +173,7 @@ private:
 			float				float_alpha_table[256];
 
 			float				transparency_coefficient;
+			float				old_transparency_coefficient;
 
 			// this function calculates the fLayerPreview
 			int32				calc_mini_image();

--- a/artpaint/layers/LayerView.cpp
+++ b/artpaint/layers/LayerView.cpp
@@ -48,8 +48,9 @@ LayerView::LayerView(BBitmap *image, Layer *layer)
 	thumbnail_view = new ThumbnailView(image);
 	thumbnail_view->SetEventMask(0);
 
+	a_message.what = HS_LAYER_NAME_CHANGED;
 	layer_name_field = new BTextControl("", "Layer",
-		new BMessage(HS_LAYER_NAME_CHANGED));
+		new BMessage(a_message));
 
 	BGroupLayout* layerLayout = BLayoutBuilder::Group<>(this,
 		B_HORIZONTAL, B_USE_SMALL_SPACING)
@@ -79,7 +80,7 @@ LayerView::AttachedToWindow()
 	if ((Parent() != NULL) && (is_active == FALSE))
 		SetViewColor(Parent()->ViewColor());
 
-	layer_name_field->SetTarget(this);
+	layer_name_field->SetTarget(the_layer->GetImageView());
 	layer_name_field->SetText(the_layer->ReturnLayerName());
 }
 
@@ -107,10 +108,6 @@ void
 LayerView::MessageReceived(BMessage *message)
 {
 	switch (message->what) {
-		case HS_LAYER_NAME_CHANGED:
-			the_layer->SetName(layer_name_field->Text());
-			break;
-
 		default:
 			BBox::MessageReceived(message);
 			break;
@@ -207,6 +204,15 @@ LayerView::SetVisibility(bool visible)
 		a_window->Unlock();
 }
 
+
+void
+LayerView::SetName(const char* name)
+{
+	if (LockLooper() == true) {
+		layer_name_field->SetText(name);
+		UnlockLooper();
+	}
+}
 
 int32
 LayerView::reorder_thread(void *data)

--- a/artpaint/layers/LayerView.h
+++ b/artpaint/layers/LayerView.h
@@ -70,6 +70,8 @@ void		Activate(bool);
 void		SetVisibility(bool);
 
 Layer*		ReturnLayer() { return the_layer; }
+const char*	ReturnLayerName() { return layer_name_field->Text(); }
+void		SetName(const char* name);
 };
 
 

--- a/artpaint/layers/LayerWindow.h
+++ b/artpaint/layers/LayerWindow.h
@@ -76,6 +76,11 @@ static	void	showLayerWindow();
 static	void	setFeel(window_feel);
 		void 	FrameResized(float, float);
 		LayerListView*	GetListView() { return list_view; }
+static	void	SetTransparency(int32 value);
+static	void	SetBlendMode(uint8 mode);
+
+		NumberSliderControl* GetTransparencySlider() { return transparency_slider; }
+		BMenu*	GetBlendModeMenu() { return blend_mode_menu; }
 };
 
 

--- a/artpaint/paintwindow/Image.cpp
+++ b/artpaint/paintwindow/Image.cpp
@@ -577,6 +577,7 @@ Image::MergeLayers(Layer *merged_layer, int32, bool merge_with_upper)
 				}
 				else if (layer->Id() == other->Id()) {
 					new_action = new UndoAction(layer->Id(),DELETE_LAYER_ACTION,layer->Bitmap()->Bounds());
+					new_event->SetLayerData(layer);
 				}
 				else
 					new_action = new UndoAction(layer->Id());
@@ -644,6 +645,7 @@ Image::RemoveLayer(Layer *removed_layer, int32 removed_layer_id)
 					new_action = new UndoAction(layer->Id());
 				else {
 					new_action = new UndoAction(layer->Id(),DELETE_LAYER_ACTION,layer->Bitmap()->Bounds());
+					new_event->SetLayerData(layer);
 				}
 				new_event->AddAction(new_action);
 				new_action->StoreUndo(layer->Bitmap());
@@ -854,6 +856,19 @@ BBitmap*
 Image::ReturnActiveBitmap()
 {
 	return ((Layer*)layer_list->ItemAt(current_layer_index))->Bitmap();
+}
+
+
+Layer*
+Image::ReturnLayerById(int32 id)
+{
+	try {
+		Layer* layer = layer_id_list[id];
+
+		return layer;
+	} catch(...) {
+		return NULL;
+	}
 }
 
 

--- a/artpaint/paintwindow/Image.h
+++ b/artpaint/paintwindow/Image.h
@@ -136,6 +136,7 @@ public:
 		Layer*		ReturnActiveLayer() {
 			return (Layer*)layer_list->ItemAt(current_layer_index);
 		}
+		Layer*		ReturnLayerById(int32 id);
 
 		int32		ReturnActiveLayerIndex() { return current_layer_index; }
 


### PR DESCRIPTION
- supports undo/redo of visibility, blend mode, transparency, and layer name.

Partially addresses #240 

The remaining piece from the ticket is layer re-arranging.  However, another area that should be improved is deleting a layer.  Currently all layer settings are lost when you delete and then undo. 