### PR TITLE
BrushTool: move drawing functions into Brush class instead of BrushTool

### DIFF
--- a/artpaint/Utilities/BitmapUtilities.cpp
+++ b/artpaint/Utilities/BitmapUtilities.cpp
@@ -170,7 +170,7 @@ BitmapUtilities::ConvertToMask(BBitmap *inBitmap, uint8 color)
 
 void
 BitmapUtilities::CompositeBitmapOnSource(BBitmap* toBuffer, BBitmap* srcBuffer, BBitmap* fromBuffer,
-	BRect updated_rect)
+	BRect updated_rect, uint32 (*composite_func)(uint32, uint32))
 {
 	updated_rect = updated_rect & toBuffer->Bounds();
 
@@ -193,7 +193,7 @@ BitmapUtilities::CompositeBitmapOnSource(BBitmap* toBuffer, BBitmap* srcBuffer, 
 	for (int y=0;y<height;y++) {
 		int32 ypos = y*bpr;
 		for (int x=0;x<width;x++) {
-			*bits++ = src_over_fixed(*(src_bits + x + ypos),
+			*bits++ = (*composite_func)(*(src_bits + x + ypos),
 				*(from_bits + x + ypos));
 		}
 		bits += bpr - width;

--- a/artpaint/Utilities/BitmapUtilities.h
+++ b/artpaint/Utilities/BitmapUtilities.h
@@ -14,6 +14,9 @@
 #include <Bitmap.h>
 
 
+#include "PixelOperations.h"
+
+
 class BitmapUtilities {
 public:
 	static	status_t	FixMissingAlpha(BBitmap *bitmap);
@@ -22,7 +25,8 @@ public:
 	static	BBitmap*	ConvertToMask(BBitmap *inBitmap, uint8 color);
 	static  void		CompositeBitmapOnSource(BBitmap* toBuffer,
 							BBitmap* srcBuffer, BBitmap* fromBuffer,
-							BRect updated_rect);
+							BRect updated_rect,
+							uint32 (*composite_func)(uint32, uint32) = src_over_fixed);
 	static  void		ClearBitmap(BBitmap* bitmap, uint32 color,
 							BRect* area = NULL);
 	static	void		CheckerBitmap(BBitmap* bitmap,

--- a/artpaint/application/MessageConstants.h
+++ b/artpaint/application/MessageConstants.h
@@ -144,4 +144,6 @@
 
 #define	HS_MANIPULATOR_FINISHED			'MnFi'
 
+#define HS_BRUSH_CHANGED				'BrCh'
+
 #endif

--- a/artpaint/paintwindow/StatusView.h
+++ b/artpaint/paintwindow/StatusView.h
@@ -11,9 +11,13 @@
 #ifndef STATUS_VIEW_H
 #define	STATUS_VIEW_H
 
+#include <Bitmap.h>
 #include <Box.h>
 #include <StringView.h>
 #include <View.h>
+
+
+#include "Brush.h"
 
 
 class BCardLayout;
@@ -22,6 +26,7 @@ class BGroupLayout;
 class BStatusBar;
 class ColorContainer;
 class SelectedColorsView;
+class CurrentBrushView;
 class HSPictureButton;
 class MagnificationView;
 
@@ -54,6 +59,7 @@ private:
 			// and the current color-set.
 			ColorContainer*		color_container;
 			SelectedColorsView*	selected_colors;
+			CurrentBrushView*	current_brush;
 
 			BCardLayout*		fCardLayout;
 			BGridLayout*		fStatusView;
@@ -84,6 +90,25 @@ private:
 private:
 			float				foreground_color_percentage;
 	static	BList				list_of_views;
+};
+
+
+class CurrentBrushView : public BView {
+public:
+								CurrentBrushView(BRect frame);
+	virtual						~CurrentBrushView();
+
+	static	CurrentBrushView*	CreateCurrentBrushView(BRect frame);
+
+	virtual void				Draw(BRect updateRect);
+	virtual void				MessageReceived(BMessage* message);
+
+			void				SetBrush(Brush* new_brush);
+	static	void				BrushChanged();
+private:
+			Brush*				fBrush;
+			BBitmap*			fBrushPreview;
+	static	CurrentBrushView*	fCurrentBrushView;
 };
 
 #endif	// STATUS_VIEW_H

--- a/artpaint/tools/Brush.h
+++ b/artpaint/tools/Brush.h
@@ -24,10 +24,12 @@
 #ifndef BRUSH_H
 #define BRUSH_H
 
+#include <Bitmap.h>
+#include <Point.h>
 #include <SupportDefs.h>
 
 
-class BBitmap;
+#include "Selection.h"
 
 
 #define	BRUSH_PREVIEW_WIDTH		64
@@ -123,19 +125,25 @@ class Brush {
 
 
 public:
-		Brush(brush_info &info,bool create_diff_brushes=TRUE);
-		~Brush();
+					Brush(brush_info &info,
+						bool create_diff_brushes = TRUE);
+					~Brush();
 
-void	ModifyBrush(brush_info &info);
-void	CreateDiffBrushes();
+	void			ModifyBrush(brush_info &info);
+	void			CreateDiffBrushes();
 
-float	PreviewBrush(BBitmap*);
+	float			PreviewBrush(BBitmap*);
+	void			draw(BBitmap* buffer, BPoint point,
+						int32 dx, int32 dy, uint32 c,
+						Selection* selection);
+	BRect			draw_line(BBitmap* buffer, BPoint start,
+						BPoint end, uint32 color,
+						Selection* selection);
 
-
-uint32**	GetData(span**,int32,int32);
-float		Width() { return width_; }
-float		Height() { return height_; }
-brush_info	GetInfo();
+	uint32**		GetData(span**,int32,int32);
+	float			Width() { return width_; }
+	float			Height() { return height_; }
+	brush_info		GetInfo();
 };
 
 #endif

--- a/artpaint/tools/BrushTool.h
+++ b/artpaint/tools/BrushTool.h
@@ -36,14 +36,7 @@ public:
 			status_t			readSettings(BFile& file, bool isLittleEndian);
 			status_t			writeSettings(BFile& file);
 
-			Brush*				GetBrush() { return brush; }
-
 private:
-			BRect				draw_line(BBitmap*, BPoint, BPoint,
-									uint32);
-	inline	void				draw_brush(BBitmap*, BPoint,
-									int32, int32, uint32);
-
 //			int32				read_coordinates();
 //	static	int32				CoordinateReader(void*);
 
@@ -51,14 +44,6 @@ private:
 			BPoint				last_point;
 			bool				reading_coordinates;
 
-			int32				bpr;
-			int32				left_bound;
-			int32				right_bound;
-			int32				top_bound;
-			int32				bottom_bound;
-
-			uint32*				bits;
-			Brush*				brush;
 			Selection*			selection;
 			ImageView*			image_view;
 			CoordinateQueue*	coordinate_queue;

--- a/artpaint/tools/ToolManager.h
+++ b/artpaint/tools/ToolManager.h
@@ -14,6 +14,9 @@
 #include <SupportDefs.h>
 
 
+#include "Brush.h"
+
+
 class BFile;
 class BPoint;
 class BPopUpMenu;
@@ -71,7 +74,7 @@ public:
 			int32					ReturnActiveToolType() const;
 			BView*					ConfigView(int32);
 			status_t				SetCurrentBrush(brush_info*);
-
+			Brush*					GetCurrentBrush();
 			BPopUpMenu*				ToolPopUpMenu();
 
 			// The next function can be used to notify the ToolManager about
@@ -92,6 +95,7 @@ private:
 private:
 			BPopUpMenu*				fToolPopUpMenu;
 			DrawingTool*			fActiveTool;
+			Brush*					fActiveBrush;
 			ToolManagerClient*		fClientListHead;
 
 	static	ToolManager*			fToolManager;


### PR DESCRIPTION
Make ToolManager store brush and pass it to BrushTool 
ToolManager::GetCurrentBrush() returns default brush if brush is not defined
Add composite_func option to BitmapUtilities::CompositeBitmapOnSource 
Add BrushView to StatusView in main window; commented out for now

part of #177; still a work-in-progress but wanted to push part of it.

These changes should be invisible. 