### PR TITLE
BrushEditor: fix brush ratio calculations so brushes aren't so huge

### DIFF
--- a/artpaint/tools/BrushEditor.cpp
+++ b/artpaint/tools/BrushEditor.cpp
@@ -235,11 +235,11 @@ BrushEditor::MessageReceived(BMessage* message)
 
 				float realRatio = 1.0 / (0.9 * fabs(ratio) + 1.);
 
-				if (value < 0) {
+				if (ratio < 0) {
 					fBrushInfo.width = max_c(value, 1);
-					fBrushInfo.height = max_c(value / realRatio, 1);
+					fBrushInfo.height = max_c(value * realRatio, 1);
 				} else {
-					fBrushInfo.width = max_c(value / realRatio, 1);
+					fBrushInfo.width = max_c(value * realRatio, 1);
 					fBrushInfo.height = max_c(value, 1);
 				}
 
@@ -259,9 +259,9 @@ BrushEditor::MessageReceived(BMessage* message)
 
 				if (value < 0) {
 					fBrushInfo.width = max_c(fBrushSize->Value(), 1);
-					fBrushInfo.height = max_c(fBrushSize->Value() / realRatio, 1);
+					fBrushInfo.height = max_c(fBrushSize->Value() * realRatio, 1);
 				} else {
-					fBrushInfo.width = max_c(fBrushSize->Value() / realRatio, 1);
+					fBrushInfo.width = max_c(fBrushSize->Value() * realRatio, 1);
 					fBrushInfo.height = max_c(fBrushSize->Value(), 1);
 				}
 


### PR DESCRIPTION
I'm not sure why #499 is giving me crashies.  So for the time being, this is the minimal set of changes that should help with the crashes.  I will see if I can figure out #499 because I really want that to work, but meanwhile we can merge this. 

Fixes #498 

