### PR TITLE
Transparency Tool: use slider instead of alpha from current color

### DIFF
--- a/artpaint/tools/TransparencyTool.h
+++ b/artpaint/tools/TransparencyTool.h
@@ -51,6 +51,7 @@ public:
 private:
 		NumberSliderControl*	fSizeSlider;
 		NumberSliderControl*	fSpeedSlider;
+		NumberSliderControl*	fTransparencySlider;
 };
 
 #endif	// TRANSPARENCY_TOOL_H


### PR DESCRIPTION
- also changed "speed" to pressure and made it a percentage of the way to the chosen value.

addresses transparency part of #176 


