### PR TITLE
LayerWindow: adjust min width so that scrollbar isn't cut off.

### DIFF
--- a/artpaint/layers/LayerWindow.cpp
+++ b/artpaint/layers/LayerWindow.cpp
@@ -245,10 +245,10 @@ LayerWindow::LayerWindow(BRect frame)
 			true);
 	}
 	setFeel(feel);
-	float min_width = font.StringWidth("W") * 20;
+	float min_width = font.StringWidth("W") * 20 +
+		scroll_view->ScrollBar(B_VERTICAL)->Bounds().Width();
 
-	scroll_view->SetExplicitMinSize(BSize(min_width -
-		scroll_view->ScrollBar(B_VERTICAL)->Bounds().Width(),
+	scroll_view->SetExplicitMinSize(BSize(min_width,
 		LAYER_VIEW_HEIGHT));
 
 	if (Lock()) {


### PR DESCRIPTION
as the description says, minor tweak so scrollbar doesn't get cut off at the minimum window size.