### PR TITLE
BrushStoreWindow: don't allow duplicate brush adding

### DIFF
--- a/artpaint/tools/Brush.cpp
+++ b/artpaint/tools/Brush.cpp
@@ -27,6 +27,19 @@
 #define PI M_PI
 
 
+bool Brush::compare_brushes(brush_info one, brush_info two)
+{
+	if (one.shape == two.shape &&
+		one.width == two.width &&
+		one.height == two.height &&
+		one.angle == two.angle &&
+		one.hardness == two.hardness)
+		return true;
+
+	return false;
+}
+
+
 Brush::Brush(brush_info &info)
 {
 	// First record the data for the brush

--- a/artpaint/tools/Brush.h
+++ b/artpaint/tools/Brush.h
@@ -118,6 +118,7 @@ public:
 	BRect			draw_line(BBitmap* buffer,
 						BPoint start, BPoint end,
 						Selection* selection);
+	static bool		compare_brushes(brush_info one, brush_info two);
 
 	uint32**		GetData(span**);
 	float			Width() { return width_; }

--- a/artpaint/windows/BrushStoreWindow.h
+++ b/artpaint/windows/BrushStoreWindow.h
@@ -40,7 +40,7 @@ public:
 	void	KeyDown(const char *bytes,int32);
 	void	MouseDown(BPoint);
 
-	void	AddBrush(Brush*);
+	bool	AddBrush(Brush*);
 };
 
 


### PR DESCRIPTION
also fixed selection of brush on deletion, as well as moving between brushes with left/right arrow keys.

fixes #502 