### PR TITLE
BrushEditor: make brush preview size match brush store pane

### DIFF
--- a/artpaint/tools/BrushEditor.cpp
+++ b/artpaint/tools/BrushEditor.cpp
@@ -58,10 +58,10 @@ BrushEditor::BrushEditor(Brush* brush)
 	, fBrush(brush)
 	, fBrushInfo(fBrush->GetInfo())
 {
-	float height = BRUSH_PREVIEW_HEIGHT - kExtraEdge;
-	float width = BRUSH_PREVIEW_WIDTH - kExtraEdge;
+	float height = BRUSH_PREVIEW_HEIGHT + 2;
+	float width = BRUSH_PREVIEW_WIDTH + 2;
 
-	fBrushView = new BrushView(BRect(kExtraEdge, kExtraEdge, width, height),
+	fBrushView = new BrushView(BRect(0, 0, width, height),
 		fBrush);
 
 	BMessage* message = new BMessage(kBrushShapeChanged);
@@ -149,6 +149,7 @@ BrushEditor::BrushEditor(Brush* brush)
 			.Add(fBrushView)
 			.AddStrut(5.0)
 			.AddGroup(B_VERTICAL, 5.0)
+				.AddGlue()
 				.Add(fEllipse)
 				.Add(fRectangle)
 			.End()


### PR DESCRIPTION
Okay, they should be the same size now. I even tried to verify with Magnify. 

I actually made the brush preview larger rather than decreasing the size of the stored brushes, unless you feel strongly the other way.

Fixes #521 