### PR TITLE
ManipulatorWindow: change window feel

### DIFF
--- a/artpaint/windows/ManipulatorWindow.cpp
+++ b/artpaint/windows/ManipulatorWindow.cpp
@@ -35,7 +35,7 @@ sem_id ManipulatorWindow::sfWindowListMutex = create_sem(1, "list_mutex");
 
 ManipulatorWindow::ManipulatorWindow(BRect rect, BView* view, const char* name,
 		BWindow* master, const BMessenger& target)
-	: BWindow(rect, name, B_FLOATING_WINDOW_LOOK, B_FLOATING_APP_WINDOW_FEEL,
+	: BWindow(rect, name, B_FLOATING_WINDOW_LOOK, B_FLOATING_SUBSET_WINDOW_FEEL,
 		B_NOT_ZOOMABLE | B_NOT_ANCHORED_ON_ACTIVATE | B_NOT_CLOSABLE
 		| B_AUTO_UPDATE_SIZE_LIMITS)
 	, fManipulatorView(view)


### PR DESCRIPTION
With B_FLOATING_APP_WINDOW_FEEL the window floats over all open project windows. So, if you for example, "Rotate" on Project1 and switch to Project2, the "Rotate" window still floats above it and may confuse the user.

B_FLOATING_SUBSET_WINDOW_FEEL will only float over the invoking project window and disappear when switching projects.