### PR TITLE
NumberSliderControl: for proportional mode, re-add the subtracted 1

### DIFF
--- a/artpaint/controls/NumberSliderControl.cpp
+++ b/artpaint/controls/NumberSliderControl.cpp
@@ -166,7 +166,7 @@ NumberSliderControl::Value() const
 
 	float norm = (pow(fExp, fSlider->Position()) - 1.) / (fExp - 1.);
 
-	return (norm * range) + fMinRange;
+	return (norm * range) + fMinRange + 1.;
 }
 
 
@@ -299,7 +299,7 @@ NumberSliderControl::_ValueForPosition(float position)
 
 	float norm = (pow(fExp, position) - 1.) / (fExp - 1.);
 
-	return (norm * range) + fMinRange;
+	return (norm * range) + fMinRange + 1;
 
 }
 


### PR DESCRIPTION
- in the exponential value calculation, 1 is subtracted from the numerator and denominator, and never added back in, so the slider is 1 less than it should be.

Fixes #547 