### PR TITLE
NumberSliderControl: make sure adjusted value doesn't exceed max range

### DIFF
--- a/artpaint/controls/NumberSliderControl.cpp
+++ b/artpaint/controls/NumberSliderControl.cpp
@@ -166,7 +166,11 @@ NumberSliderControl::Value() const
 
 	float norm = (pow(fExp, fSlider->Position()) - 1.) / (fExp - 1.);
 
-	return (norm * range) + fMinRange + 1.;
+	int32 value = (norm * range) + fMinRange + 1;
+	if (value > fMaxRange)
+		value = fMaxRange;
+
+	return value;
 }
 
 
@@ -299,7 +303,11 @@ NumberSliderControl::_ValueForPosition(float position)
 
 	float norm = (pow(fExp, position) - 1.) / (fExp - 1.);
 
-	return (norm * range) + fMinRange + 1;
+	int32 value = (norm * range) + fMinRange + 1;
+	if (value > fMaxRange)
+		value = fMaxRange;
+
+	return value;
 
 }
 


### PR DESCRIPTION
finding all kinds of lil buggies... this one was introduced when I fixed the Size slider in the brush window; you can go up to 501 instead of 500!  
