### PR TITLE
ImageView: pressing DEL while in a manip executes manip and then deletes

### DIFF
--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -317,6 +317,11 @@ ImageView::KeyDown(const char* bytes, int32 numBytes)
 				delta = bitmap_rect.bottom - bounds.bottom;
 			ScrollBy(0, delta);
 		} else if (*bytes == B_DELETE) {
+			if (acquire_sem_etc(mouse_mutex, 1, B_RELATIVE_TIMEOUT, 0) == B_OK) {
+				if (fManipulator != NULL)
+					PostponeMessageAndFinishManipulator(TRUE);
+				release_sem(mouse_mutex);
+			}
 			if (BWindow* window = Window())
 				window->PostMessage(HS_EDIT_DELETE, this);
 		} else if (*bytes == B_ESCAPE) {


### PR DESCRIPTION
Fixes #570 

...but it works with ANY manipulator.  I think that's ok because I'm not sure why a user would do, say, a normal translate and then hit DEL.  But both actions are separately undoable.  I.e. if you translate and hit DEL before clicking OK, the translate happens, then the delete, and you can then undo just the delete.  

I feel like if a user does do such an action, this result is likely what they intended.