### PR TITLE
ColorFloatSlider: set fMinRange and fMaxRange in SetMinMax

### DIFF
--- a/artpaint/controls/ColorFloatSlider.cpp
+++ b/artpaint/controls/ColorFloatSlider.cpp
@@ -195,6 +195,9 @@ ColorFloatSlider::SetMinMax(float min, float max)
 {
 	fSlider->SetLimits((int32)min * fMult,
 		(int32)max * fMult);
+
+	fMinRange = min;
+	fMaxRange = max;
 }
 
 


### PR DESCRIPTION
Fixes #592 