### PR TITLE
ImageView/Image: Moved layer data copying to where layer structure is rebuilt

### DIFF
--- a/artpaint/paintwindow/Image.cpp
+++ b/artpaint/paintwindow/Image.cpp
@@ -416,6 +416,7 @@ Image::AddLayer(BBitmap *bitmap, Layer *next_layer, bool add_to_front,
 						new_action = new UndoAction(layer->Id());
 					else {
 						new_action = new UndoAction(layer->Id(),ADD_LAYER_ACTION,layer->Bitmap()->Bounds());
+						new_event->SetLayerData(layer);
 					}
 					new_event->AddAction(new_action);
 					new_action->StoreUndo(layer->Bitmap());
@@ -756,6 +757,8 @@ Image::UpdateImageStructure(UndoEvent *event)
 	}
 	UndoAction **actions = event->ReturnActions();
 	BRect updated_rect(1000000,1000000,-1000000,-1000000);
+	Layer* layer_data = event->ReturnLayerData();
+
 	for (int32 i=0;i<event->ActionCount();i++) {
 		int32 layer_id = actions[i]->LayerId();
 		Layer *layer = layer_id_list[layer_id];
@@ -795,6 +798,14 @@ Image::UpdateImageStructure(UndoEvent *event)
 					"create mini picture", B_LOW_PRIORITY,
 					layer_id_list[layer_id]);
 				resume_thread(a_thread);
+				BString new_name(layer_data->ReturnLayerName());
+				float new_transparency = layer_data->GetTransparency();
+				uint8 new_blend_mode = layer_data->GetBlendMode();
+				bool new_visibility = layer_data->IsVisible();
+				layer_id_list[layer_id]->SetName(new_name);
+				layer_id_list[layer_id]->SetTransparency(new_transparency);
+				layer_id_list[layer_id]->SetBlendMode(new_blend_mode);
+				layer_id_list[layer_id]->SetVisibility(new_visibility);
 			}
 			delete bitmap;
 		}

--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -2294,25 +2294,22 @@ ImageView::Undo()
 			if (event->ReturnLayerData() != NULL) {
 				Layer* layer_data = event->ReturnLayerData();
 				Layer* active_layer = the_image->ReturnLayerById(layer_data->Id());
+
 				if (active_layer != NULL) {
+					BString new_name(layer_data->ReturnLayerName());
+					float new_transparency = layer_data->GetTransparency();
+					uint8 new_blend_mode = layer_data->GetBlendMode();
+					bool new_visibility = layer_data->IsVisible();
+
 					active_layer->ActivateLayer(true);
 					the_image->ChangeActiveLayer(active_layer, 0);
-					BString new_name(layer_data->ReturnLayerName());
 					BString old_name(active_layer->ReturnLayerName());
-					active_layer->SetName(new_name);
-					active_layer->GetView()->SetName(new_name);
 					layer_data->SetName(old_name);
-					float new_transparency = layer_data->GetTransparency();
 					float old_transparency = active_layer->GetTransparency();
-					active_layer->SetTransparency(new_transparency);
 					layer_data->SetTransparency(old_transparency);
-					uint8 new_blend_mode = layer_data->GetBlendMode();
 					uint8 old_blend_mode = active_layer->GetBlendMode();
-					active_layer->SetBlendMode(new_blend_mode);
 					layer_data->SetBlendMode(old_blend_mode);
-					bool new_visibility = layer_data->IsVisible();
 					bool old_visibility = active_layer->IsVisible();
-					active_layer->SetVisibility(new_visibility);
 					layer_data->SetVisibility(old_visibility);
 					LayerWindow::SetTransparency(new_transparency * 100);
 					LayerWindow::SetBlendMode(new_blend_mode);
@@ -2386,25 +2383,22 @@ ImageView::Redo()
 			if (event->ReturnLayerData() != NULL) {
 				Layer* layer_data = event->ReturnLayerData();
 				Layer* active_layer = the_image->ReturnLayerById(layer_data->Id());
+
 				if (active_layer != NULL) {
+					BString new_name(layer_data->ReturnLayerName());
+					float new_transparency = layer_data->GetTransparency();
+					uint8 new_blend_mode = layer_data->GetBlendMode();
+					bool new_visibility = layer_data->IsVisible();
+
 					active_layer->ActivateLayer(true);
 					the_image->ChangeActiveLayer(active_layer, 0);
-					BString new_name(layer_data->ReturnLayerName());
 					BString old_name(active_layer->ReturnLayerName());
-					active_layer->SetName(new_name);
-					active_layer->GetView()->SetName(new_name);
 					layer_data->SetName(old_name);
-					float new_transparency = layer_data->GetTransparency();
 					float old_transparency = active_layer->GetTransparency();
-					active_layer->SetTransparency(new_transparency);
 					layer_data->SetTransparency(old_transparency);
-					uint8 new_blend_mode = layer_data->GetBlendMode();
 					uint8 old_blend_mode = active_layer->GetBlendMode();
-					active_layer->SetBlendMode(new_blend_mode);
 					layer_data->SetBlendMode(old_blend_mode);
-					bool new_visibility = layer_data->IsVisible();
 					bool old_visibility = active_layer->IsVisible();
-					active_layer->SetVisibility(new_visibility);
 					layer_data->SetVisibility(old_visibility);
 					LayerWindow::SetTransparency(new_transparency * 100);
 					LayerWindow::SetBlendMode(new_blend_mode);


### PR DESCRIPTION
This is a better fix for #240 I believe.  It fixes the undo-redo-undo-redo of deleted layers that didn't quite work before:

1. create a layer
2. rename it
3. delete it
4. undo delete layer, layer reappears with correct name
5. redo delete layer
6. undo delete layer, layer reappears with correct name <- this didn't work before this fix.  Now you can undo and redo and the layer properties come back 

Still missing from #240 is layer re-ordering, but at least I think this works better. 