### PR TITLE
PaintWindow: Removed B_NOT_ANCHORED_ON_ACTIVATE flag

### DIFF
--- a/artpaint/paintwindow/PaintWindow.cpp
+++ b/artpaint/paintwindow/PaintWindow.cpp
@@ -101,7 +101,7 @@ struct menu_item {
 PaintWindow::PaintWindow(BRect frame, const char* name, uint32 views,
 		const BMessage& settings)
 	: BWindow(frame, name, B_TITLED_WINDOW_LOOK, B_NORMAL_WINDOW_FEEL,
-		B_WILL_ACCEPT_FIRST_CLICK | B_NOT_ANCHORED_ON_ACTIVATE | B_AUTO_UPDATE_SIZE_LIMITS)
+		B_WILL_ACCEPT_FIRST_CLICK | B_AUTO_UPDATE_SIZE_LIMITS)
 	, fSettings(settings)
 	, fImageView(NULL)
 	, fBackground(NULL)


### PR DESCRIPTION
Fixes #299 

...it must have been done on purpose, but I really don't know why.  