### PR TITLE
Selection: store selection map for undo/redo instead of polygonal data

### DIFF
--- a/artpaint/application/Selection.h
+++ b/artpaint/application/Selection.h
@@ -121,6 +121,8 @@ public:
 		// This function adds a binary bitmap to the selection.
 		void			AddSelection(BBitmap*, bool add_to_selection);
 
+		void			ReplaceSelection(BBitmap*);
+
 		// This function clears the selection.
 		void			Clear();
 
@@ -177,6 +179,8 @@ public:
 		void			ImageSizeChanged(BRect);
 
 const	SelectionData*	ReturnSelectionData() { return selection_data; }
+
+BBitmap*		ReturnSelectionMap() { return selection_map; }
 
 		// These functions return true if the point in parameter belongs to the
 		// selection (i.e. is not DEselected). The BPoint version will also

--- a/artpaint/application/UndoEvent.cpp
+++ b/artpaint/application/UndoEvent.cpp
@@ -30,6 +30,7 @@ UndoEvent::UndoEvent(const BString& name, const BBitmap*)
 	previous_event = NULL;
 
 	selection_data = NULL;
+	selection_map = NULL;
 	layer_data = NULL;
 }
 
@@ -45,6 +46,7 @@ UndoEvent::~UndoEvent()
 	delete[] actions;
 
 	delete selection_data;
+	delete selection_map;
 
 	delete layer_data;
 }
@@ -100,10 +102,19 @@ bool UndoEvent::IsEmpty()
 }
 
 
-void UndoEvent::SetSelectionData(const SelectionData *s)
+void
+UndoEvent::SetSelectionData(const SelectionData *s)
 {
 	delete selection_data;
 	selection_data = new SelectionData(s);
+}
+
+
+void
+UndoEvent::SetSelectionMap(const BBitmap* new_map)
+{
+	delete selection_map;
+	selection_map = new BBitmap(new_map);
 }
 
 

--- a/artpaint/application/UndoEvent.h
+++ b/artpaint/application/UndoEvent.h
@@ -36,6 +36,7 @@ friend 	class		UndoQueue;
 		UndoEvent	*previous_event;
 
 	SelectionData	*selection_data;
+		BBitmap*	selection_map;
 
 		Layer*		layer_data;
 
@@ -57,6 +58,9 @@ BBitmap*		ReturnThumbnail() { return thumbnail_image; }
 
 SelectionData*	ReturnSelectionData() { return selection_data; }
 void			SetSelectionData(const SelectionData*);
+
+BBitmap*		ReturnSelectionMap() { return selection_map; }
+void			SetSelectionMap(const BBitmap* new_map);
 
 void			SetLayerData(Layer*);
 Layer*			ReturnLayerData() { return layer_data; }

--- a/artpaint/application/UndoQueue.cpp
+++ b/artpaint/application/UndoQueue.cpp
@@ -48,6 +48,7 @@ UndoQueue::UndoQueue(BMenuItem *undo_item,BMenuItem *redo_item,ImageView *iv)
 	queue_list->AddItem(this);
 
 	selection_data = new SelectionData();
+	selection_map = NULL;
 
 	UpdateMenuItems();
 }
@@ -76,6 +77,8 @@ UndoQueue::~UndoQueue()
 	delete[] layer_bitmaps;
 
 	delete selection_data;
+	delete selection_map;
+
 }
 
 
@@ -535,6 +538,14 @@ UndoQueue::SetSelectionData(const SelectionData *s)
 {
 	delete selection_data;
 	selection_data = new SelectionData(s);
+}
+
+
+void
+UndoQueue::SetSelectionMap(const BBitmap* new_map)
+{
+	delete selection_map;
+	selection_map = new BBitmap(new_map);
 }
 
 

--- a/artpaint/application/UndoQueue.h
+++ b/artpaint/application/UndoQueue.h
@@ -52,6 +52,7 @@ const	char*		ReturnRedoEventName();
 
 
 SelectionData*		selection_data;
+BBitmap*			selection_map;
 Layer*				layer_data;
 
 public:
@@ -90,6 +91,9 @@ void		RegisterLayer(int32 layer_id,BBitmap *layer_bitmap);
 
 SelectionData*	ReturnSelectionData() { return selection_data; }
 void	SetSelectionData(const SelectionData*);
+
+BBitmap*		ReturnSelectionMap() { return selection_map; }
+void			SetSelectionMap(const BBitmap* new_map);
 
 bool		IsEmpty() { return (ReturnUndoEventName() == NULL); }
 

--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -759,14 +759,15 @@ ImageView::MessageReceived(BMessage* message)
 		case HS_INVERT_SELECTION: {
 			if (!fManipulator) {
 				selection->Invert();
-				if (!(*undo_queue->ReturnSelectionData() ==
-					*selection->ReturnSelectionData())) {
+
+				if (!(undo_queue->ReturnSelectionMap() ==
+					selection->ReturnSelectionMap())) {
 					UndoEvent* new_event =
 						undo_queue->AddUndoEvent(B_TRANSLATE("Invert selection"),
 							the_image->ReturnThumbnailImage());
 					if (new_event != NULL) {
-						new_event->SetSelectionData(undo_queue->ReturnSelectionData());
-						undo_queue->SetSelectionData(selection->ReturnSelectionData());
+						new_event->SetSelectionMap(undo_queue->ReturnSelectionMap());
+						undo_queue->SetSelectionMap(selection->ReturnSelectionMap());
 					}
 				}
 
@@ -779,14 +780,14 @@ ImageView::MessageReceived(BMessage* message)
 		case HS_CLEAR_SELECTION: {
 			if (!fManipulator) {
 				selection->Clear();
-				if (!(*undo_queue->ReturnSelectionData() ==
-					*selection->ReturnSelectionData())) {
+				if (!(undo_queue->ReturnSelectionMap() ==
+					selection->ReturnSelectionMap())) {
 					UndoEvent* new_event =
 						undo_queue->AddUndoEvent(B_TRANSLATE("Select none"),
 							the_image->ReturnThumbnailImage());
 					if (new_event != NULL) {
-						new_event->SetSelectionData(undo_queue->ReturnSelectionData());
-						undo_queue->SetSelectionData(selection->ReturnSelectionData());
+						new_event->SetSelectionMap(undo_queue->ReturnSelectionMap());
+						undo_queue->SetSelectionMap(selection->ReturnSelectionMap());
 					}
 				}
 
@@ -804,12 +805,12 @@ ImageView::MessageReceived(BMessage* message)
 		case HS_SELECT_ALL: {
 			if (!fManipulator) {
 				selection->SelectAll();
-				if (!(*undo_queue->ReturnSelectionData() == *selection->ReturnSelectionData())) {
+				if (!(undo_queue->ReturnSelectionMap() == selection->ReturnSelectionMap())) {
 					UndoEvent *new_event = undo_queue->AddUndoEvent(B_TRANSLATE("Select all"),
 						the_image->ReturnThumbnailImage());
 					if (new_event != NULL) {
-						new_event->SetSelectionData(undo_queue->ReturnSelectionData());
-						undo_queue->SetSelectionData(selection->ReturnSelectionData());
+						new_event->SetSelectionMap(undo_queue->ReturnSelectionMap());
+						undo_queue->SetSelectionMap(selection->ReturnSelectionMap());
 					}
 				}
 
@@ -827,16 +828,17 @@ ImageView::MessageReceived(BMessage* message)
 				BBitmap* selection_map =
 					BitmapUtilities::ConvertToMask(layerBitmap, 0xFF);
 				selection->AddSelection(selection_map, true);
-				if (!(*undo_queue->ReturnSelectionData() ==
-					*selection->ReturnSelectionData())) {
+				if (!(undo_queue->ReturnSelectionMap() ==
+					selection->ReturnSelectionMap())) {
 					UndoEvent* new_event =
 						undo_queue->AddUndoEvent(B_TRANSLATE("Select non-transparent"),
 							the_image->ReturnThumbnailImage());
 					if (new_event != NULL) {
-						new_event->SetSelectionData(undo_queue->ReturnSelectionData());
-						undo_queue->SetSelectionData(selection->ReturnSelectionData());
+						new_event->SetSelectionMap(undo_queue->ReturnSelectionMap());
+						undo_queue->SetSelectionMap(selection->ReturnSelectionMap());
 					}
 				}
+
 
 				// Tell the selection to start drawing itself.
 				if (show_selection == TRUE)
@@ -849,14 +851,14 @@ ImageView::MessageReceived(BMessage* message)
 		case HS_GROW_SELECTION: {
 			if (!fManipulator) {
 				selection->Dilate();
-				if (!(*undo_queue->ReturnSelectionData() ==
-					*selection->ReturnSelectionData())) {
+				if (!(undo_queue->ReturnSelectionMap() ==
+					selection->ReturnSelectionMap())) {
 					UndoEvent* new_event =
 						undo_queue->AddUndoEvent(B_TRANSLATE("Grow selection"),
 							the_image->ReturnThumbnailImage());
 					if (new_event != NULL) {
-						new_event->SetSelectionData(undo_queue->ReturnSelectionData());
-						undo_queue->SetSelectionData(selection->ReturnSelectionData());
+						new_event->SetSelectionMap(undo_queue->ReturnSelectionMap());
+						undo_queue->SetSelectionMap(selection->ReturnSelectionMap());
 					}
 				}
 				Invalidate();
@@ -866,14 +868,14 @@ ImageView::MessageReceived(BMessage* message)
 		case HS_SHRINK_SELECTION: {
 			if (!fManipulator) {
 				selection->Erode();
-				if (!(*undo_queue->ReturnSelectionData() ==
-					*selection->ReturnSelectionData())) {
+				if (!(undo_queue->ReturnSelectionMap() ==
+					selection->ReturnSelectionMap())) {
 					UndoEvent* new_event =
 						undo_queue->AddUndoEvent(B_TRANSLATE("Shrink selection"),
 							the_image->ReturnThumbnailImage());
 					if (new_event != NULL) {
-						new_event->SetSelectionData(undo_queue->ReturnSelectionData());
-						undo_queue->SetSelectionData(selection->ReturnSelectionData());
+						new_event->SetSelectionMap(undo_queue->ReturnSelectionMap());
+						undo_queue->SetSelectionMap(selection->ReturnSelectionMap());
 					}
 				}
 				Invalidate();
@@ -1785,16 +1787,16 @@ ImageView::PaintToolThread()
 				}
 			} else if (tool_type == SELECTOR_TOOL) {
 				// Add selection-change to the undo-queue.
-				if (!(*undo_queue->ReturnSelectionData() ==
-					*selection->ReturnSelectionData())) {
+				if (!(undo_queue->ReturnSelectionMap() ==
+					selection->ReturnSelectionMap())) {
 					const DrawingTool* used_tool =
 						ToolManager::Instance().ReturnTool(tool_type);
 					UndoEvent* new_event =
 						undo_queue->AddUndoEvent(used_tool->Name(),
 							the_image->ReturnThumbnailImage());
 					if (new_event != NULL) {
-						new_event->SetSelectionData(undo_queue->ReturnSelectionData());
-						undo_queue->SetSelectionData(selection->ReturnSelectionData());
+						new_event->SetSelectionMap(undo_queue->ReturnSelectionMap());
+						undo_queue->SetSelectionMap(selection->ReturnSelectionMap());
 					}
 				}
 
@@ -2066,14 +2068,14 @@ ImageView::ManipulatorFinisherThread()
 			manipName == B_TRANSLATE("Rotate selection") ||
 			manipName == B_TRANSLATE("Scale selection")) {
 			// Add selection-change to the undo-queue.
-			if (!(*undo_queue->ReturnSelectionData() ==
-				*selection->ReturnSelectionData())) {
+			if (!(undo_queue->ReturnSelectionMap() ==
+				selection->ReturnSelectionMap())) {
 				UndoEvent* new_event =
 					undo_queue->AddUndoEvent(manipName,
 						the_image->ReturnThumbnailImage());
 				if (new_event != NULL) {
-					new_event->SetSelectionData(undo_queue->ReturnSelectionData());
-					undo_queue->SetSelectionData(selection->ReturnSelectionData());
+					new_event->SetSelectionMap(undo_queue->ReturnSelectionMap());
+					undo_queue->SetSelectionMap(selection->ReturnSelectionMap());
 				}
 			}
 		} else {
@@ -2207,10 +2209,10 @@ ImageView::ManipulatorFinisherThread()
 
 	// Change the selection for the undo-queue if necessary.
 	if ((new_event != NULL) &&
-		!(*undo_queue->ReturnSelectionData() ==
-			*selection->ReturnSelectionData())) {
-		new_event->SetSelectionData(undo_queue->ReturnSelectionData());
-		undo_queue->SetSelectionData(selection->ReturnSelectionData());
+		!(undo_queue->ReturnSelectionMap() ==
+			selection->ReturnSelectionMap())) {
+		new_event->SetSelectionMap(undo_queue->ReturnSelectionMap());
+		undo_queue->SetSelectionMap(selection->ReturnSelectionMap());
 	}
 
 	// Store the manipulator settings.
@@ -2281,14 +2283,14 @@ ImageView::Undo()
 				RemoveChange();
 			}
 
-			if (event->ReturnSelectionData() != NULL) {
-				SelectionData* data = new SelectionData(
-					event->ReturnSelectionData());
-				event->SetSelectionData(selection->ReturnSelectionData());
-				selection->SetSelectionData(data);
+			if (event->ReturnSelectionMap() != NULL) {
+				BBitmap* selection_map = new BBitmap(
+					event->ReturnSelectionMap());
+				event->SetSelectionMap(selection->ReturnSelectionMap());
+				selection->ReplaceSelection(selection_map);
 
-				undo_queue->SetSelectionData(data);
-				delete data;
+				undo_queue->SetSelectionMap(selection_map);
+				delete selection_map;
 			}
 
 			if (event->ReturnLayerData() != NULL) {
@@ -2370,14 +2372,14 @@ ImageView::Redo()
 					the_image->LayerList(), the_image->ReturnThumbnailImage());
 				AddChange();
 			}
-			if (event->ReturnSelectionData() != NULL) {
-				SelectionData* data = new SelectionData(
-					event->ReturnSelectionData());
-				event->SetSelectionData(selection->ReturnSelectionData());
-				selection->SetSelectionData(data);
+			if (event->ReturnSelectionMap() != NULL) {
+				BBitmap* selection_map = new BBitmap(
+					event->ReturnSelectionMap());
+				event->SetSelectionMap(selection->ReturnSelectionMap());
+				selection->ReplaceSelection(selection_map);
 
-				undo_queue->SetSelectionData(data);
-				delete data;
+				undo_queue->SetSelectionMap(selection_map);
+				delete selection_map;
 			}
 
 			if (event->ReturnLayerData() != NULL) {

--- a/artpaint/viewmanipulators/RotationManipulator.cpp
+++ b/artpaint/viewmanipulators/RotationManipulator.cpp
@@ -44,7 +44,7 @@
 RotationManipulator::RotationManipulator(BBitmap* bitmap)
 	:	WindowGUIManipulator(),
 	selection(NULL),
-	orig_selection_data(NULL),
+	orig_selection_map(NULL),
 	transform_selection_only(false)
 {
 	settings = new RotationManipulatorSettings();
@@ -78,6 +78,11 @@ RotationManipulator::~RotationManipulator()
 	if (config_view != NULL) {
 		config_view->RemoveSelf();
 		delete config_view;
+	}
+
+	if (orig_selection_map != NULL) {
+		delete orig_selection_map;
+		orig_selection_map = NULL;
 	}
 }
 
@@ -357,10 +362,9 @@ RotationManipulator::ManipulateBitmap(ManipulatorSettings* set, BBitmap* origina
 			}
 		}
 	} else {
-		if (orig_selection_data != NULL) {
-			selection->SetSelectionData(orig_selection_data);
-			selection->Recalculate();
-		}
+		if (orig_selection_map != NULL)
+			selection->ReplaceSelection(orig_selection_map);
+
 		// This should be done by first rotating the selection and then looking up what pixels
 		// of original image correspond to the pixels in the rotated selection. The only problem
 		// with this approach is if we want to clear the selection first so we must clear it before
@@ -615,6 +619,9 @@ RotationManipulator::Reset()
 
 		memcpy(target, source, bits_length);
 	}
+
+	if (orig_selection_map != NULL && selection != NULL)
+		selection->ReplaceSelection(orig_selection_map);
 }
 
 
@@ -660,7 +667,7 @@ RotationManipulator::SetSelection(Selection* new_selection)
 {
 	selection = new_selection;
 	if (selection != NULL && selection->IsEmpty() == false) {
-		orig_selection_data = new SelectionData(selection->ReturnSelectionData());
+		orig_selection_map = new BBitmap(selection->ReturnSelectionMap());
 
 		BRect bounds = selection->GetBoundingRect();
 

--- a/artpaint/viewmanipulators/RotationManipulator.h
+++ b/artpaint/viewmanipulators/RotationManipulator.h
@@ -62,7 +62,7 @@ class RotationManipulator: public WindowGUIManipulator {
 	bool		move_origo;
 
 	Selection*	selection;
-	SelectionData*	orig_selection_data;
+	BBitmap*	orig_selection_map;
 	bool		transform_selection_only;
 
 public:

--- a/artpaint/viewmanipulators/ScaleManipulator.h
+++ b/artpaint/viewmanipulators/ScaleManipulator.h
@@ -91,7 +91,7 @@ class ScaleManipulator : public WindowGUIManipulator {
 	float		previous_bottom;
 
 	Selection*	selection;
-	SelectionData*	orig_selection_data;
+	BBitmap*	orig_selection_map;
 	bool		transform_selection_only;
 
 	BPoint		previous_point;


### PR DESCRIPTION
Another in the chain of selection changes... this change is what I needed for #597, but I ran into the other issues along the way so I had to fix them first.

Anyway, what this change does is store the selection *bitmap* for undo and redo operations.  Previously the selection outlines were stored, not the bitmaps.  Using the bitmaps means we can store the grayscale (aka alpha) values for selections instead of just the shapes.  When blurred or painted selections are available, this will be critical. 

It'll use more memory but it's needed for more interesting functionality. 

I was also secretly hoping this might fix #608 and it seems to?