### PR TITLE
ImageView: make sure to restart selection drawing after undo/redo

### DIFF
--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -2291,6 +2291,9 @@ ImageView::Undo()
 
 				undo_queue->SetSelectionMap(selection_map);
 				delete selection_map;
+
+				if (show_selection == true)
+					selection->StartDrawing(this, magnify_scale);
 			}
 
 			if (event->ReturnLayerData() != NULL) {
@@ -2380,6 +2383,9 @@ ImageView::Redo()
 
 				undo_queue->SetSelectionMap(selection_map);
 				delete selection_map;
+
+				if (show_selection == true)
+					selection->StartDrawing(this, magnify_scale);
 			}
 
 			if (event->ReturnLayerData() != NULL) {


### PR DESCRIPTION
Missed a spot with #598 / #599

to reproduce the problem:

1. load image
2. Select all non-transparent
3. Selection -> None (Alt + D)
4. Undo 
- note the ants don't crawl
