### PR TITLE
StraightLineTool: don't add 1 to even-numbered widths

### DIFF
--- a/artpaint/tools/BitmapDrawer.cpp
+++ b/artpaint/tools/BitmapDrawer.cpp
@@ -329,7 +329,7 @@ BitmapDrawer::_DrawShearedEllipse(BPoint center, float width, float height, uint
 			if (anti_alias == true) {
 				float error = x - fx;
 
-                color2.word = color;
+				color2.word = color;
 
 				uint8 alpha = round((1.0 - error) * color1.bytes[3]);
 

--- a/artpaint/tools/StraightLineTool.cpp
+++ b/artpaint/tools/StraightLineTool.cpp
@@ -144,8 +144,6 @@ StraightLineTool::UseTool(ImageView* view, uint32 buttons, BPoint point, BPoint 
 		float brush_width_per_2;
 		float brush_height_per_2;
 		int diameter = fToolSettings.size;
-		if ((diameter % 2) == 0)
-			diameter++;
 
 		if (fToolSettings.use_current_brush == true) {
 			brush = ToolManager::Instance().GetCurrentBrush();


### PR DESCRIPTION
Addressed the "straight line" part of #618 

For some strange reason the width had 1 added to it if it was an even number?  No idea why but it seems to work fine without that. 

