### PR TITLE
Selection: transform selections via bitmaps, not polygons

### DIFF
--- a/artpaint/Utilities/ScaleUtilities.cpp
+++ b/artpaint/Utilities/ScaleUtilities.cpp
@@ -160,6 +160,56 @@ ScaleUtilities::ScaleVertically(float width, float height, BPoint offset, BBitma
 
 
 void
+ScaleUtilities::ScaleHorizontallyGray(float width, float height, BPoint offset, BBitmap* source,
+	BBitmap* target, float ratio)
+{
+	uint8* target_bits = (uint8*)target->Bits();
+	int32 target_bpr = target->BytesPerRow();
+	uint8* source_bits = (uint8*)source->Bits();
+	int32 source_bpr = source->BytesPerRow();
+
+	for (int32 y = 0; y < (int32)ceil(height + 0.5); y++) {
+		uint8* src_bits = source_bits + (int32)offset.x + (y + (int32)offset.y) * source_bpr;
+
+		for (int32 x = 0; x < (int32)width; x++) {
+			int32 low = floor(ratio * x);
+			int32 high = ceil(ratio * x);
+			float weight = ratio * x - low;
+
+			*(target_bits + x + y * target_bpr)
+				= linear_interpolation(*(src_bits + low),
+					*(src_bits + high), weight);
+		}
+	}
+}
+
+
+void
+ScaleUtilities::ScaleVerticallyGray(float width, float height, BPoint offset, BBitmap* source,
+	BBitmap* target, float ratio)
+{
+	uint8* target_bits = (uint8*)target->Bits();
+	int32 target_bpr = target->BytesPerRow();
+	uint8* source_bits = (uint8*)source->Bits();
+	int32 source_bpr = source->BytesPerRow();
+
+	for (int32 y = 0; y <= (int32)height; y++) {
+		int32 low = floor(ratio * y);
+		int32 high = ceil(ratio * y);
+		float weight = (ratio * y) - low;
+		uint8* src_bits_low = source_bits + (int32)offset.x + (low + (int32)ceil(offset.y + 0.5)) * source_bpr;
+		uint8* src_bits_high = source_bits + (int32)offset.x + (high + (int32)ceil(offset.y + 0.5)) * source_bpr;
+
+		for (int32 x = 0; x <= width; x++) {
+			*(target_bits + x + y * target_bpr)
+				= linear_interpolation(*(src_bits_low + x),
+					*(src_bits_high + x), weight);
+		}
+	}
+}
+
+
+void
 ScaleUtilities::MoveGrabbers(BPoint point, BPoint& previous, float& left, float& top, float& right,
 	float& bottom, float aspect_ratio, bool& move_left, bool& move_top, bool& move_right,
 	bool& move_bottom, bool& move_all, bool first_click, bool lock_aspect)

--- a/artpaint/Utilities/ScaleUtilities.h
+++ b/artpaint/Utilities/ScaleUtilities.h
@@ -68,6 +68,10 @@ public:
 	static void		ScaleVertically(float width, float height, BPoint offset,
 						BBitmap* source, BBitmap* target,
 						float ratio, interpolation_type method);
+	static void		ScaleHorizontallyGray(float width, float height, BPoint offset,
+						BBitmap* source, BBitmap* target, float ratio);
+	static void		ScaleVerticallyGray(float width, float height, BPoint offset,
+						BBitmap* source, BBitmap* target, float ratio);
 };
 
 

--- a/artpaint/application/PixelOperations.h
+++ b/artpaint/application/PixelOperations.h
@@ -119,6 +119,15 @@ inline uint32 combine_4_pixels_fixed(uint32 p1, uint32 p2, uint32 p3, uint32 p4,
 }
 
 
+inline uint8 bilinear_interpolation(uint8 p1, uint8 p2, uint8 p3, uint8 p4, float u, float v)
+{
+	float one_minus_v = 1.0 - v;
+	float one_minus_u = 1.0 - u;
+
+	return one_minus_v * (one_minus_u * p1 +  u * p2) + v * (one_minus_u * p3 + u * p4);
+}
+
+
 // Parameters u and v should be in range [0,1]
 inline uint32 bilinear_interpolation(uint32 p1, uint32 p2, uint32 p3, uint32 p4, float u, float v)
 {

--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -1982,6 +1982,17 @@ ImageView::ManipulatorFinisherThread()
 			|| manipName == B_TRANSLATE("Rotate selection")
 			|| manipName == B_TRANSLATE("Scale selection")) {
 			// Add selection-change to the undo-queue.
+
+			if (gui_manipulator != NULL) {
+				ManipulatorSettings* settings = gui_manipulator->ReturnSettings();
+
+				BBitmap* new_buffer = gui_manipulator->ManipulateSelectionMap(settings);
+				delete settings;
+
+				if (new_buffer != NULL)
+					selection->ReplaceSelection(new_buffer);
+			}
+
 			if (!(undo_queue->ReturnSelectionMap() == selection->ReturnSelectionMap())) {
 				UndoEvent* new_event = undo_queue->AddUndoEvent(manipName,
 					the_image->ReturnThumbnailImage());

--- a/artpaint/viewmanipulators/GUIManipulator.h
+++ b/artpaint/viewmanipulators/GUIManipulator.h
@@ -60,6 +60,8 @@ public:
 			void		EnableWindow(bool enable) { fEnabled = enable; }
 			bool		IsWindowEnabled() { return fEnabled; }
 
+	virtual	BBitmap*	ManipulateSelectionMap(ManipulatorSettings*) { return NULL; }
+
 private:
 			bool		fEnabled;
 };

--- a/artpaint/viewmanipulators/RotationManipulator.h
+++ b/artpaint/viewmanipulators/RotationManipulator.h
@@ -95,6 +95,7 @@ public:
 						{ transform_selection_only = select_only; }
 
 		void		UpdateSettings();
+		BBitmap*	ManipulateSelectionMap(ManipulatorSettings*);
 };
 
 

--- a/artpaint/viewmanipulators/ScaleManipulator.h
+++ b/artpaint/viewmanipulators/ScaleManipulator.h
@@ -134,6 +134,7 @@ public:
 
 	void		SetInterpolationMethod(interpolation_type newMethod) { method = newMethod; }
 	void		UpdateSettings();
+	BBitmap*	ManipulateSelectionMap(ManipulatorSettings*);
 };
 
 

--- a/artpaint/viewmanipulators/TranslationManipulator.h
+++ b/artpaint/viewmanipulators/TranslationManipulator.h
@@ -49,6 +49,7 @@ class TranslationManipulator : public WindowGUIManipulator {
 			int32		highest_available_quality;
 
 			Selection*	selection;
+			BBitmap*	orig_selection_map;
 			bool		transform_selection_only;
 
 public:
@@ -70,12 +71,12 @@ public:
 
 			ManipulatorSettings*	ReturnSettings();
 			void		SetValues(float, float);
-			void		SetSelection(Selection* new_selection)
-							{ selection = new_selection; };
+			void		SetSelection(Selection* new_selection);
 			void		SetTransformSelectionOnly(bool select_only)
 							{ transform_selection_only = select_only; }
 
 			void		UpdateSettings();
+			BBitmap*	ManipulateSelectionMap(ManipulatorSettings*);
 };
 
 


### PR DESCRIPTION
Fixes #621 

Not sure how to test this one other than just making sure the translate, rotate, and scale selections work at least as well as before.

I tested with rectangle, ellipse, freehand, and "select all non-transparent pixels" selections, both on new, blank canvases and existing pngs like Walter_the_OS, with undoing and redoing and such.  

Filed #625 for the one issue I found that is also present in master before this change.

