### PR TITLE
Rectangle/Ellipse: Add "Outline width" slider

### DIFF
--- a/artpaint/tools/DrawingTool.cpp
+++ b/artpaint/tools/DrawingTool.cpp
@@ -171,6 +171,10 @@ DrawingTool::SetOption(int32 option, int32 value, BHandler* source)
 				if (BControl* control = dynamic_cast<BCheckBox*>(source))
 					fToolSettings.use_current_brush = control->Value();
 			} break;
+			case WIDTH_OPTION:
+			{
+				fToolSettings.width = value;
+			} break;
 			default:
 				break;
 		}
@@ -211,6 +215,8 @@ DrawingTool::GetCurrentValue(int32 option)
 				return fToolSettings.transparency;
 			case USE_BRUSH_OPTION:
 				return fToolSettings.use_current_brush;
+			case WIDTH_OPTION:
+				return fToolSettings.width;
 			default:
 				return 0;
 		}

--- a/artpaint/tools/EllipseTool.h
+++ b/artpaint/tools/EllipseTool.h
@@ -22,6 +22,14 @@ class ImageView;
 class ToolScript;
 
 
+namespace ArtPaint {
+	namespace Interface {
+		class NumberSliderControl;
+	}
+}
+using ArtPaint::Interface::NumberSliderControl;
+
+
 class EllipseTool : public DrawingTool, public ToolEventAdapter {
 public:
 								EllipseTool();
@@ -41,6 +49,7 @@ public:
 	virtual						~EllipseToolConfigView() {}
 
 	virtual	void				AttachedToWindow();
+	virtual void				MessageReceived(BMessage* message);
 
 private:
 			BCheckBox*			fFillEllipse;
@@ -48,6 +57,7 @@ private:
 			BRadioButton*		fCenter2Corner;
 			BCheckBox*			fAntiAlias;
 			BCheckBox*          fRotation;
+			NumberSliderControl* fLineWidth;
 };
 
 

--- a/artpaint/tools/RectangleTool.h
+++ b/artpaint/tools/RectangleTool.h
@@ -22,6 +22,14 @@ class ImageView;
 class ToolScript;
 
 
+namespace ArtPaint {
+	namespace Interface {
+		class NumberSliderControl;
+	}
+}
+using ArtPaint::Interface::NumberSliderControl;
+
+
 class RectangleTool : public DrawingTool, public ToolEventAdapter {
 public:
 								RectangleTool();
@@ -41,6 +49,7 @@ public:
 	virtual						~RectangleToolConfigView() {}
 
 	virtual	void				AttachedToWindow();
+	virtual void				MessageReceived(BMessage* message);
 
 private:
 			BCheckBox*			fFillRectangle;
@@ -48,6 +57,7 @@ private:
 			BRadioButton*		fCenter2Corner;
 			BCheckBox*			fRotation;
 			BCheckBox*			fAntiAlias;
+			NumberSliderControl* fLineWidth;
 };
 
 

--- a/artpaint/tools/Tools.h
+++ b/artpaint/tools/Tools.h
@@ -23,7 +23,7 @@ enum {
 };
 
 
-#define	TOOL_SETTINGS_STRUCT_VERSION	0x00000002
+#define	TOOL_SETTINGS_STRUCT_VERSION	0x00000003
 
 
 // Here is enumeration that defines the drawing tool constants. After adding a
@@ -65,7 +65,8 @@ enum option_constants {
 	CONTINUITY_OPTION			=	0x00000800,		// B_CONTROL_ON means continuous execution of tool.
 	TOLERANCE_OPTION			=	0x00001000,
 	TRANSPARENCY_OPTION			=	0x00002000,
-	USE_BRUSH_OPTION			= 	0x00004000
+	USE_BRUSH_OPTION			= 	0x00004000,
+	WIDTH_OPTION				=	0x00008000
 };
 
 
@@ -108,6 +109,7 @@ struct tool_settings {
 	int32	tolerance;
 	int32	transparency;
 	int32 	use_current_brush;
+	int32	width;
 };
 
 


### PR DESCRIPTION
Addresses #174 

... I'm not sure about the "Adjustable outline width" option.  Would that happen *after* rotation?  I didn't add that part for now. 

A few caveats; the preview drawing has some issues where it doesn't draw correctly, but the actual drawn shape is usually correct. For example: 

1. With large widths, a rotating rectangle gets the corners cut off, but when you click to accept it, the rectangle draws properly with no cutoff corners. 
2. With large widths and small rectangles, there's a diamond-shape drawn in the center - seems like maybe a bug with Haiku's PenSize, where if it's larger than the shape you're drawing there are artifacts?

(1) might also be weird Haiku view drawing behavior?