### PR TITLE
Crop/Scale Canvas Maniplators: fixed off-by-1 errors

### DIFF
--- a/artpaint/paintwindow/Image.cpp
+++ b/artpaint/paintwindow/Image.cpp
@@ -1070,9 +1070,9 @@ Image::calculate_thumbnail_image(void* data)
 	color.bytes[2] = 0xFF;
 	color.bytes[3] = 0x00;
 
-	int32 miniature_width = (int32)(
+	uint32 miniature_width = (uint32)(
 		(to->Bounds().Width() + 1) * (min_c(from->Bounds().Width() / from->Bounds().Height(), 1)));
-	int32 miniature_height = (int32)(
+	uint32 miniature_height = (uint32)(
 		(to->Bounds().Height() + 1) * (min_c(from->Bounds().Height() / from->Bounds().Width(), 1)));
 
 	// Here we copy the contents of the_bitmap to miniature image.

--- a/artpaint/viewmanipulators/CropManipulator.cpp
+++ b/artpaint/viewmanipulators/CropManipulator.cpp
@@ -114,12 +114,12 @@ CropManipulator::Draw(BView* view, float mag_scale)
 	// Draw all the data that needs to be drawn
 	BRect bounds = BRect(mag_scale * settings->left,
 		mag_scale * settings->top,
-		mag_scale * (settings->right + 1) - 1,
-		mag_scale * (settings->bottom + 1) - 1);
+		mag_scale * (settings->right) - 1,
+		mag_scale * (settings->bottom) - 1);
 	bounds.left = floor(bounds.left);
 	bounds.top = floor(bounds.top);
-	bounds.right = ceil(bounds.right);
-	bounds.bottom = ceil(bounds.bottom);
+	bounds.right = ceil(bounds.right) - 1;
+	bounds.bottom = ceil(bounds.bottom) - 1;
 
 	bool draw_draggers = FALSE;
 	BRect dragger_rect = BRect(0, 0, DRAGGER_SIZE - 1, DRAGGER_SIZE - 1);
@@ -200,12 +200,12 @@ CropManipulator::ManipulateBitmap(
 		return NULL;
 
 	float left = new_settings->left;
-	float right = new_settings->right;
+	float right = new_settings->right - 1;
 	float top = new_settings->top;
-	float bottom = new_settings->bottom;
+	float bottom = new_settings->bottom - 1;
 
-	float width = right - left - 1;
-	float height = bottom - top - 1;
+	float width = ceil(right - left);
+	float height = ceil(bottom - top);
 
 	if (width == original->Bounds().Width()
 		&& height == original->Bounds().Height()


### PR DESCRIPTION
New fix for #552 - now you can crop to 1x1 and it's actually 1x1, and I believe other crops are accurate too. 

Also fixed Canvas->Resize since it's kind of the same thing (and had the same problem).

I didn't mess with Edit->Scale; I think it's also off by 1 but it's a lot hairier in general. 