### PR TITLE
BrushStoreWindow: fix broken check for duplicate brushes

### DIFF
--- a/artpaint/windows/BrushStoreWindow.cpp
+++ b/artpaint/windows/BrushStoreWindow.cpp
@@ -493,7 +493,8 @@ BrushStoreView::AddBrush(Brush* brush)
 		brush_info item = *(brush_info*)brush_data->ItemAt(i);
 		if (Brush::compare_brushes(item, new_brush_info) == true) {
 			index = i;
-		} break;
+			break;
+		}
 	}
 
 	if (index < 0) {


### PR DESCRIPTION
- break statement was erroneously moved during The Big Cleanup, and it allowed duplicate brushes to be added to Brush window.