### PR TITLE
BrushEditor: size preview based on max dimension to avoid jumping

### DIFF
--- a/artpaint/paintwindow/StatusView.cpp
+++ b/artpaint/paintwindow/StatusView.cpp
@@ -395,8 +395,7 @@ CurrentBrushView::CurrentBrushView(BRect frame)
 
 	SetToolTip(B_TRANSLATE("Brush"));
 
-	frame.InsetBy(1.0, 1.0);
-	fBrushPreview = new BBitmap(BRect(0.0, 0.0, frame.Width(), frame.Height()), B_RGBA32);
+	fBrushPreview = new BBitmap(BRect(0.0, 0.0, frame.Width(), frame.Height()), B_RGBA32, true);
 	BitmapUtilities::ClearBitmap(fBrushPreview, 0xFFFFFFFF);
 
 	list_of_views.AddItem(this);
@@ -412,11 +411,7 @@ CurrentBrushView::~CurrentBrushView()
 
 void CurrentBrushView::Draw(BRect)
 {
-	DrawBitmap(fBrushPreview, BPoint(1.0, 1.0));
-
-	SetPenSize(1);
-	SetHighColor(0, 0, 0, 255);
-	StrokeRect(Bounds());
+	DrawBitmap(fBrushPreview, BPoint(0.0, 0.0));
 }
 
 

--- a/artpaint/tools/BrushEditor.cpp
+++ b/artpaint/tools/BrushEditor.cpp
@@ -374,9 +374,8 @@ BrushView::BrushView(BRect frame, Brush* brush)
 
 	SetToolTip(B_TRANSLATE("Hold SHIFT to snap to 45° angles"));
 
-	frame.InsetBy(1.0, 1.0);
 	fBrushPreview
-		= new BBitmap(BRect(0.0, 0.0, frame.Width() - 1.0, frame.Height() - 1.0), B_RGBA32);
+		= new BBitmap(BRect(0.0, 0.0, frame.Width(), frame.Height()), B_RGBA32, true);
 	fBrush->PreviewBrush(fBrushPreview);
 }
 
@@ -389,11 +388,7 @@ BrushView::~BrushView()
 
 void BrushView::Draw(BRect)
 {
-	DrawBitmap(fBrushPreview, BPoint(1.0, 1.0));
-
-	SetPenSize(1);
-	SetHighColor(0, 0, 0, 255);
-	StrokeRect(Bounds());
+	DrawBitmap(fBrushPreview, BPoint(0.0, 0.0));
 
 	if (fDrawControls) {
 		float r1 = Bounds().Width() / 2;

--- a/artpaint/windows/BrushStoreWindow.cpp
+++ b/artpaint/windows/BrushStoreWindow.cpp
@@ -310,17 +310,18 @@ BrushStoreView::Draw(BRect area)
 	SetPenSize(1.0);
 	for (int32 i = 0; i < brush_images->CountItems(); i++) {
 		if ((area & get_bitmap_frame(i)).IsValid() == TRUE) {
-			DrawBitmapAsync((BBitmap*)brush_images->ItemAt(i), get_bitmap_frame(i));
+			SetHighColor(ui_color(B_PANEL_BACKGROUND_COLOR));
 			BRect outer_frame = get_bitmap_frame(i);
-			outer_frame.InsetBy(-1, -1);
-			StrokeRect(outer_frame);
+			DrawBitmap((BBitmap*)brush_images->ItemAt(i), get_bitmap_frame(i));
+			StrokeRect(outer_frame.InsetByCopy(-1, -1));
+			StrokeRect(outer_frame.InsetByCopy(-2, -2));
 		}
 	}
 	if (IsFocus() && (brush_data->CountItems() > 0)) {
 		SetHighColor(ui_color(B_NAVIGATION_BASE_COLOR));
 		BRect outer_frame = get_bitmap_frame(selected_brush_index);
 		SetPenSize(1.5);
-		StrokeRect(outer_frame);
+		StrokeRect(outer_frame.InsetByCopy(-1, -1));
 	}
 	Sync();
 }
@@ -483,7 +484,7 @@ BrushStoreView::AddBrush(Brush* brush)
 	bool added = false;
 
 	BBitmap* a_bitmap
-		= new BBitmap(BRect(0, 0, BRUSH_PREVIEW_WIDTH - 1, BRUSH_PREVIEW_HEIGHT - 1), B_RGB_32_BIT);
+		= new BBitmap(BRect(0, 0, BRUSH_PREVIEW_WIDTH, BRUSH_PREVIEW_HEIGHT), B_RGB_32_BIT, true);
 
 	brush_info new_brush_info = brush->GetInfo();
 


### PR DESCRIPTION
Fixes #523 

(but watch out for #643 when testing, which is unrelated to this change)