### PR TITLE
Layer/ImageView: respect alpha value when cutting/copying/deleting

### DIFF
--- a/artpaint/layers/Layer.cpp
+++ b/artpaint/layers/Layer.cpp
@@ -155,8 +155,13 @@ Layer::Clear(rgb_color color)
 		int32 bpr = fLayerData->BytesPerRow() / 4;
 		for (int32 y = top; y <= bottom; ++y) {
 			for (int32 x = left; x <= right; ++x) {
-				if (selection->ContainsPoint(x, y))
-					*(bits + x + y * bpr) = color_bits;
+				if (selection->ContainsPoint(x, y)) {
+					union color_conversion norm_color;
+					norm_color.word = color_bits;
+					norm_color.bytes[3] = selection->Value(x, y);
+
+					*(bits + x + y * bpr) = dst_out_fixed(*(bits + x + y * bpr), norm_color.word);
+				}
 			}
 		}
 	}

--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -2353,10 +2353,7 @@ ImageView::DoCopyOrCut(int32 layers, bool cut)
 			BBitmap* to_be_archived = new BBitmap(bounds, B_RGBA32, 0); // stargater, Pete
 			uint32* target_bits = (uint32*)to_be_archived->Bits();
 			int32 bits_length = to_be_archived->BitsLength() / 4;
-			union {
-				uint8 bytes[4];
-				uint32 word;
-			} color;
+			union color_conversion color, norm_color;
 			color.bytes[0] = 0xFF;
 			color.bytes[1] = 0xFF;
 			color.bytes[2] = 0xFF;
@@ -2376,9 +2373,13 @@ ImageView::DoCopyOrCut(int32 layers, bool cut)
 
 			for (int32 y = top; y <= bottom; y++) {
 				for (int32 x = left; x <= right; x++) {
-					if (selection->ContainsPoint(x, y))
-						*target_bits = *(source_bits + x + y * source_bpr);
+					if (selection->ContainsPoint(x, y)) {
+						norm_color.word = color.word;
+						norm_color.bytes[3] = 0xFF - selection->Value(x, y);
 
+						*target_bits =
+							dst_out_fixed(*(source_bits + x + y * source_bpr), norm_color.word);
+					}
 					target_bits++;
 				}
 			}


### PR DESCRIPTION
Missed a spot with the "respecting alpha in selections" changes, and I expect there could be a few more spots hiding along the way - the cut/copy/delete now respects selection alpha. 

The easiest way to describe this is with some pictures - load up Walter, then make a layer with a gradient on it:
![0walt](https://github.com/HaikuArchives/ArtPaint/assets/10878750/9df34d12-7273-4a7c-9013-f44b78edce8c)

...then "Select all non-transparent" on that gradient layer and then hide that layer...
![1walt](https://github.com/HaikuArchives/ArtPaint/assets/10878750/fd5172d6-3472-446a-b933-35efb2e4efa6)

...go to the Walter layer and hit the Delete key. 

the `master` branch does this :disappointed: 
![3walt](https://github.com/HaikuArchives/ArtPaint/assets/10878750/4447ab3f-2dcf-4670-af65-ea1c54402759)

But with this change, it does this, as it should:
![2walt](https://github.com/HaikuArchives/ArtPaint/assets/10878750/5ae66734-fd0c-4cc6-81a7-e570e7c598c7)

You can also cut/copy/paste with alphaed selections. 