### PR TITLE
StatusView: don't notify about brush preview until after brushes are loaded

### DIFF
--- a/artpaint/tools/Brush.cpp
+++ b/artpaint/tools/Brush.cpp
@@ -89,7 +89,7 @@ Brush::~Brush()
 
 
 void
-Brush::ModifyBrush(brush_info& info)
+Brush::ModifyBrush(brush_info& info, bool notify)
 {
 	delete_all_data();
 
@@ -135,7 +135,8 @@ Brush::ModifyBrush(brush_info& info)
 		shapes[i] = new_polygon;
 	}
 
-	CurrentBrushView::SendMessageToAll(HS_BRUSH_CHANGED);
+	if (notify == true)
+		CurrentBrushView::SendMessageToAll(HS_BRUSH_CHANGED);
 }
 
 

--- a/artpaint/tools/Brush.h
+++ b/artpaint/tools/Brush.h
@@ -97,7 +97,7 @@ public:
 						Brush(brush_info &info);
 						~Brush();
 
-			void		ModifyBrush(brush_info &info);
+			void		ModifyBrush(brush_info &info, bool notify = true);
 			void		CreateDiffBrushes();
 
 			float		PreviewBrush(BBitmap*);

--- a/artpaint/tools/ToolManager.cpp
+++ b/artpaint/tools/ToolManager.cpp
@@ -251,13 +251,13 @@ ToolManager::ReturnActiveToolType() const
 
 
 status_t
-ToolManager::SetCurrentBrush(brush_info* binfo)
+ToolManager::SetCurrentBrush(brush_info* binfo, bool notify)
 {
 	// Set the new brush for all tools that use brushes.
 	if (fActiveBrush == NULL)
 		fActiveBrush = new Brush(*binfo);
 	else
-		fActiveBrush->ModifyBrush(*binfo);
+		fActiveBrush->ModifyBrush(*binfo, notify);
 
 	if (fActiveBrush == NULL)
 		return B_ERROR;
@@ -266,7 +266,8 @@ ToolManager::SetCurrentBrush(brush_info* binfo)
 
 	fActiveBrush->CreateDiffBrushes();
 
-	CurrentBrushView::SendMessageToAll(HS_BRUSH_CHANGED);
+	if (notify == true)
+		CurrentBrushView::SendMessageToAll(HS_BRUSH_CHANGED);
 
 	return B_OK;
 }

--- a/artpaint/tools/ToolManager.h
+++ b/artpaint/tools/ToolManager.h
@@ -73,7 +73,7 @@ public:
 			DrawingTool*		ReturnActiveTool() const { return fActiveTool; }
 			int32				ReturnActiveToolType() const;
 			BView*				ConfigView(int32);
-			status_t			SetCurrentBrush(brush_info*);
+			status_t			SetCurrentBrush(brush_info*, bool notify = true);
 			Brush*				GetCurrentBrush();
 			BPopUpMenu*			ToolPopUpMenu();
 

--- a/artpaint/windows/BrushStoreWindow.cpp
+++ b/artpaint/windows/BrushStoreWindow.cpp
@@ -248,8 +248,8 @@ BrushStoreWindow::brush_adder(void* data)
 			Brush* a_brush = new Brush(*(brush_info*)(temp_list.ItemAt(0)));
 
 			for (int32 i = 0; i < temp_list.CountItems(); i++) {
-				a_brush->ModifyBrush(*(brush_info*)(temp_list.ItemAt(i)));
-				this_pointer->store_view->AddBrush(a_brush);
+				a_brush->ModifyBrush(*(brush_info*)(temp_list.ItemAt(i)), false);
+				this_pointer->store_view->AddBrush(a_brush, false);
 			}
 
 			delete a_brush;
@@ -483,7 +483,7 @@ BrushStoreView::MouseDown(BPoint point)
 
 
 bool
-BrushStoreView::AddBrush(Brush* brush)
+BrushStoreView::AddBrush(Brush* brush, bool notify)
 {
 	bool added = false;
 
@@ -517,7 +517,7 @@ BrushStoreView::AddBrush(Brush* brush)
 		Draw(Bounds());
 	}
 
-	ToolManager::Instance().SetCurrentBrush(((brush_info*)brush_data->ItemAt(index)));
+	ToolManager::Instance().SetCurrentBrush(((brush_info*)brush_data->ItemAt(index)), notify);
 
 	ResizeBy(-1, 0);
 	ResizeBy(1, 0);

--- a/artpaint/windows/BrushStoreWindow.h
+++ b/artpaint/windows/BrushStoreWindow.h
@@ -40,7 +40,7 @@ public:
 			void		KeyDown(const char* bytes, int32);
 			void		MouseDown(BPoint);
 
-			bool		AddBrush(Brush*);
+			bool		AddBrush(Brush*, bool notify = true);
 };
 
 
@@ -63,7 +63,7 @@ public:
 
 	static	void		writeBrushes(BFile&);
 	static	void		readBrushes(BFile&);
-	static	void		AddBrush(Brush*);
+	static	void		AddBrush(Brush* brush);
 	static	void		DeleteBrush(int32);
 
 	static	void		showWindow();


### PR DESCRIPTION
This is a follow-on to #647 - prevents StatusView from drawing the brush preview until after they are loaded.