### PR TITLE
Brush: fix brush size shown in preview

### DIFF
--- a/artpaint/tools/Brush.cpp
+++ b/artpaint/tools/Brush.cpp
@@ -438,7 +438,8 @@ Brush::PreviewBrush(BBitmap* preview_bitmap)
 	BFont font;
 	font.SetSize(bmap_width / 6);
 	BString brushSizeString;
-	brushSizeString.SetToFormat("%d", (int32)max_dim - 2);
+	float brushSize = max_c(actual_width, actual_height);
+	brushSizeString.SetToFormat("%d", (int32)brushSize);
 
 	int32 strWidth = font.StringWidth("000");
 	font_height strHeight;


### PR DESCRIPTION
Introduced in #644, can't believe we didn't catch it!  For rectangular brushes, the size number in the brush preview changed with the Brush angle...ooops...  fixed now!