### PR TITLE
Added manipulators to flip a selection vertically and horizontally

### DIFF
--- a/artpaint/paintwindow/ImageView.cpp
+++ b/artpaint/paintwindow/ImageView.cpp
@@ -1985,7 +1985,9 @@ ImageView::ManipulatorFinisherThread()
 		BString manipName = fManipulator->ReturnName();
 		if (manipName == B_TRANSLATE("Translate selection")
 			|| manipName == B_TRANSLATE("Rotate selection")
-			|| manipName == B_TRANSLATE("Scale selection")) {
+			|| manipName == B_TRANSLATE("Scale selection")
+			|| manipName == B_TRANSLATE("Flip selection horizontally")
+			|| manipName == B_TRANSLATE("Flip selection vertically")) {
 			// Add selection-change to the undo-queue.
 
 			if (gui_manipulator != NULL) {
@@ -1994,6 +1996,10 @@ ImageView::ManipulatorFinisherThread()
 				BBitmap* new_buffer = gui_manipulator->ManipulateSelectionMap(settings);
 				delete settings;
 
+				if (new_buffer != NULL)
+					selection->ReplaceSelection(new_buffer);
+			} else {
+				BBitmap* new_buffer = fManipulator->ManipulateSelectionMap();
 				if (new_buffer != NULL)
 					selection->ReplaceSelection(new_buffer);
 			}

--- a/artpaint/paintwindow/PaintWindow.cpp
+++ b/artpaint/paintwindow/PaintWindow.cpp
@@ -1270,6 +1270,18 @@ PaintWindow::openMenuBar()
 	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Scale" B_UTF8_ELLIPSIS), a_message, 'E',
 		B_CONTROL_KEY, this, B_TRANSLATE("Scale the selection.")));
 	menu->AddSeparatorItem();
+	a_message = new BMessage(HS_START_MANIPULATOR);
+	a_message->AddInt32("manipulator_type", HORIZ_FLIP_SELECTION_MANIPULATOR);
+	a_message->AddInt32("layers", HS_MANIPULATE_CURRENT_LAYER);
+	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Flip horizontally"), a_message, B_LEFT_ARROW,
+		B_OPTION_KEY, this, B_TRANSLATE("Flips the selection horizontally.")));
+	a_message = new BMessage(HS_START_MANIPULATOR);
+	a_message->AddInt32("manipulator_type", VERT_FLIP_SELECTION_MANIPULATOR);
+	a_message->AddInt32("layers", HS_MANIPULATE_CURRENT_LAYER);
+	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Flip vertically"), a_message, B_UP_ARROW,
+		B_OPTION_KEY, this, B_TRANSLATE("Flips the selection vertically.")));
+
+	menu->AddSeparatorItem();
 	menu->AddItem(new PaintWindowMenuItem(B_TRANSLATE("Hide borders"),
 		new BMessage(HS_HIDE_SELECTION_BORDERS), 'H', 0, this,
 		B_TRANSLATE("Hides the selection borders.")));

--- a/artpaint/paintwindow/PaintWindow.cpp
+++ b/artpaint/paintwindow/PaintWindow.cpp
@@ -534,6 +534,22 @@ PaintWindow::MenusBeginning()
 			else
 				item->SetEnabled(true);
 		}
+
+		item = selectionMenu->FindItem(B_TRANSLATE("Flip horizontally"));
+		if (item != NULL) {
+			if (fImageView->GetSelection()->IsEmpty())
+				item->SetEnabled(false);
+			else
+				item->SetEnabled(true);
+		}
+
+		item = selectionMenu->FindItem(B_TRANSLATE("Flip vertically"));
+		if (item != NULL) {
+			if (fImageView->GetSelection()->IsEmpty())
+				item->SetEnabled(false);
+			else
+				item->SetEnabled(true);
+		}
 	}
 
 	if ((fImageEntry.InitCheck() == B_OK) && (fCurrentHandler != 0)) {

--- a/artpaint/viewmanipulators/FlipManipulator.cpp
+++ b/artpaint/viewmanipulators/FlipManipulator.cpp
@@ -28,7 +28,8 @@
 
 HorizFlipManipulator::HorizFlipManipulator()
 	:
-	Manipulator()
+	Manipulator(),
+	transform_selection_only(false)
 {
 }
 
@@ -58,37 +59,39 @@ HorizFlipManipulator::ManipulateBitmap(BBitmap* original, BStatusBar* status_bar
 	if (selection == NULL || selection->IsEmpty() == true)
 		has_selection = false;
 
-	for (int32 y = top; y <= bottom; y++) {
-		for (int32 x = left; x <= right_per_2; x++) {
-			uint32* bit = bits + y * bpr;
-			int32 right_x = left + right - x;
-			right_bits = *(bit + right_x);
-			left_bits = *(bit + x);
-			if (has_selection == true) {
-				if (selection->ContainsPoint(x, y))
-					*(bit + x) = 0;
-				if (selection->ContainsPoint(right_x, y))
-					*(bit + right_x) = 0;
+	if (transform_selection_only == false) {
+		for (int32 y = top; y <= bottom; y++) {
+			for (int32 x = left; x <= right_per_2; x++) {
+				uint32* bit = bits + y * bpr;
+				int32 right_x = left + right - x;
+				right_bits = *(bit + right_x);
+				left_bits = *(bit + x);
+				if (has_selection == true) {
+					if (selection->ContainsPoint(x, y))
+						*(bit + x) = 0;
+					if (selection->ContainsPoint(right_x, y))
+						*(bit + right_x) = 0;
 
-				if (selection->ContainsPoint(x, y))
-					*(bit + right_x) = left_bits;
-				if (selection->ContainsPoint(right_x, y))
+					if (selection->ContainsPoint(x, y))
+						*(bit + right_x) = left_bits;
+					if (selection->ContainsPoint(right_x, y))
+						*(bit + x) = right_bits;
+				} else {
 					*(bit + x) = right_bits;
-			} else {
-				*(bit + x) = right_bits;
-				*(bit + right_x) = left_bits;
+					*(bit + right_x) = left_bits;
+				}
 			}
-		}
 
-		if ((y % 40 == 0) && (status_bar != NULL) && (status_bar->Window() != NULL)) {
-			BMessage* a_message = new BMessage(B_UPDATE_STATUS_BAR);
-			a_message->AddFloat("delta", 40.0 * 100.0 / (float)height);
-			status_bar->Window()->PostMessage(a_message, status_bar);
-			delete a_message;
+			if ((y % 40 == 0) && (status_bar != NULL) && (status_bar->Window() != NULL)) {
+				BMessage* a_message = new BMessage(B_UPDATE_STATUS_BAR);
+				a_message->AddFloat("delta", 40.0 * 100.0 / (float)height);
+				status_bar->Window()->PostMessage(a_message, status_bar);
+				delete a_message;
+			}
 		}
 	}
 
-	if (selection != NULL) {
+	if (has_selection == true) {
 		BBitmap* sel_map = ManipulateSelectionMap();
 		selection->ReplaceSelection(sel_map);
 	}
@@ -144,13 +147,17 @@ HorizFlipManipulator::ManipulateSelectionMap()
 const char*
 HorizFlipManipulator::ReturnName()
 {
+	if (transform_selection_only == true)
+		return B_TRANSLATE("Flip selection horizontally");
+
 	return B_TRANSLATE("Flip horizontally");
 }
 
 
 VertFlipManipulator::VertFlipManipulator()
 	:
-	Manipulator()
+	Manipulator(),
+	transform_selection_only(false)
 {
 }
 
@@ -179,37 +186,39 @@ VertFlipManipulator::ManipulateBitmap(BBitmap* original, BStatusBar* status_bar)
 	if (selection == NULL || selection->IsEmpty() == true)
 		has_selection = false;
 
-	for (int32 y = top; y <= bottom_per_2; y++) {
-		for (int32 x = left; x <= right; x++) {
-			uint32* bit = bits; // + y * bpr;
-			int32 bottom_y = top + bottom - y;
-			bottom_bits = *(bit + x + bottom_y * bpr);
-			top_bits = *(bit + x + y * bpr);
-			if (has_selection == true) {
-				if (selection->ContainsPoint(x, y))
-					*(bit + x + y * bpr) = 0;
-				if (selection->ContainsPoint(x, bottom_y))
-					*(bit + x + bottom_y * bpr) = 0;
+	if (transform_selection_only == false) {
+		for (int32 y = top; y <= bottom_per_2; y++) {
+			for (int32 x = left; x <= right; x++) {
+				uint32* bit = bits; // + y * bpr;
+				int32 bottom_y = top + bottom - y;
+				bottom_bits = *(bit + x + bottom_y * bpr);
+				top_bits = *(bit + x + y * bpr);
+				if (has_selection == true) {
+					if (selection->ContainsPoint(x, y))
+						*(bit + x + y * bpr) = 0;
+					if (selection->ContainsPoint(x, bottom_y))
+						*(bit + x + bottom_y * bpr) = 0;
 
-				if (selection->ContainsPoint(x, y))
-					*(bit + x + bottom_y * bpr) = top_bits;
-				if (selection->ContainsPoint(x, bottom_y))
+					if (selection->ContainsPoint(x, y))
+						*(bit + x + bottom_y * bpr) = top_bits;
+					if (selection->ContainsPoint(x, bottom_y))
+						*(bit + x + y * bpr) = bottom_bits;
+				} else {
 					*(bit + x + y * bpr) = bottom_bits;
-			} else {
-				*(bit + x + y * bpr) = bottom_bits;
-				*(bit + x + bottom_y * bpr) = top_bits;
+					*(bit + x + bottom_y * bpr) = top_bits;
+				}
 			}
-		}
 
-		if ((y % 40 == 0) && (status_bar != NULL) && (status_bar->Window() != NULL)) {
-			BMessage* a_message = new BMessage(B_UPDATE_STATUS_BAR);
-			a_message->AddFloat("delta", 40.0 * 100.0 / (float)height_per_2);
-			status_bar->Window()->PostMessage(a_message, status_bar);
-			delete a_message;
+			if ((y % 40 == 0) && (status_bar != NULL) && (status_bar->Window() != NULL)) {
+				BMessage* a_message = new BMessage(B_UPDATE_STATUS_BAR);
+				a_message->AddFloat("delta", 40.0 * 100.0 / (float)height_per_2);
+				status_bar->Window()->PostMessage(a_message, status_bar);
+				delete a_message;
+			}
 		}
 	}
 
-	if (selection != NULL) {
+	if (has_selection == true) {
 		BBitmap* sel_map = ManipulateSelectionMap();
 		selection->ReplaceSelection(sel_map);
 	}
@@ -264,5 +273,8 @@ VertFlipManipulator::ManipulateSelectionMap()
 const char*
 VertFlipManipulator::ReturnName()
 {
+	if (transform_selection_only == true)
+		return B_TRANSLATE("Flip selection vertically");
+
 	return B_TRANSLATE("Flip vertically");
 }

--- a/artpaint/viewmanipulators/FlipManipulator.h
+++ b/artpaint/viewmanipulators/FlipManipulator.h
@@ -19,11 +19,14 @@ public:
 
 		const char*		ReturnName();
 		void			SetSelection(Selection* new_selection) { selection = new_selection; };
+        void		    SetTransformSelectionOnly(bool select_only)
+                            { transform_selection_only = select_only; }
 
 		BBitmap*		ManipulateSelectionMap();
 
 private:
 		Selection*		selection;
+        bool            transform_selection_only;
 };
 
 
@@ -34,11 +37,14 @@ public:
 
 		const char*		ReturnName();
 		void			SetSelection(Selection* new_selection) { selection = new_selection; };
+        void		    SetTransformSelectionOnly(bool select_only)
+                            { transform_selection_only = select_only; }
 
 		BBitmap*		ManipulateSelectionMap();
 
 private:
 		Selection*		selection;
+        bool            transform_selection_only;
 };
 
 

--- a/artpaint/viewmanipulators/Manipulator.h
+++ b/artpaint/viewmanipulators/Manipulator.h
@@ -47,7 +47,9 @@ enum manipulator_type {
 	VERT_FLIP_MANIPULATOR,
 	TRANSLATE_SELECTION_MANIPULATOR,
 	ROTATE_SELECTION_MANIPULATOR,
-	SCALE_SELECTION_MANIPULATOR
+	SCALE_SELECTION_MANIPULATOR,
+	HORIZ_FLIP_SELECTION_MANIPULATOR,
+	VERT_FLIP_SELECTION_MANIPULATOR
 };
 
 
@@ -66,6 +68,7 @@ public:
 	double							GetSystemClockSpeed() { return fSystemClockSpeed; }
 	int								GetSystemCpuCount() { return fCpuCount; }
 	virtual void					SetSelection(Selection* new_selection) = 0;
+	virtual BBitmap*				ManipulateSelectionMap() { return NULL; }
 
 protected:
 			BBitmap*				DuplicateBitmap(BBitmap* source,

--- a/artpaint/viewmanipulators/ManipulatorServer.cpp
+++ b/artpaint/viewmanipulators/ManipulatorServer.cpp
@@ -139,9 +139,19 @@ ManipulatorServer::ManipulatorFor(manipulator_type type, image_id imageId) const
 		{
 			manipulator = new HorizFlipManipulator();
 		} break;
+		case HORIZ_FLIP_SELECTION_MANIPULATOR:
+		{
+			manipulator = new HorizFlipManipulator();
+			((HorizFlipManipulator*)manipulator)->SetTransformSelectionOnly(true);
+		} break;
 		case VERT_FLIP_MANIPULATOR:
 		{
 			manipulator = new VertFlipManipulator();
+		} break;
+		case VERT_FLIP_SELECTION_MANIPULATOR:
+		{
+			manipulator = new VertFlipManipulator();
+			((VertFlipManipulator*)manipulator)->SetTransformSelectionOnly(true);
 		} break;
 		case ROTATE_CW_MANIPULATOR:
 		{


### PR DESCRIPTION
Added manipulators in the Selection menu to flip a selection in either direction. tested on a 4k image and 8k, and with multiple layers (all layers and active layer both work)

Fixes #641