### PR TITLE
only round up height in ScaleHorizontally when image sizes are odd numbers

### DIFF
--- a/artpaint/Utilities/ScaleUtilities.cpp
+++ b/artpaint/Utilities/ScaleUtilities.cpp
@@ -14,12 +14,20 @@ void
 ScaleUtilities::ScaleHorizontally(float width, float height, BPoint offset, BBitmap* source,
 	BBitmap* target, float ratio, interpolation_type method)
 {
+	target->Lock();
 	uint32* target_bits = (uint32*)target->Bits();
 	int32 target_bpr = target->BytesPerRow() / 4;
+	target->Unlock();
+	source->Lock();
 	uint32* source_bits = (uint32*)source->Bits();
 	int32 source_bpr = source->BytesPerRow() / 4;
+	source->Unlock();
 
-	for (int32 y = 0; y < (int32)ceil(height + 0.5); y++) {
+	int32 normHeight = height;
+	if (((int32)height) % 2 == 0 && ratio > 1.0)
+		normHeight = (int32)ceil(height + 0.5);
+
+	for (int32 y = 0; y < normHeight; y++) {
 		uint32* src_bits = source_bits + (int32)offset.x + (y + (int32)offset.y) * source_bpr;
 
 		for (int32 x = 0; x <= (int32)width; x++) {
@@ -84,10 +92,14 @@ void
 ScaleUtilities::ScaleVertically(float width, float height, BPoint offset, BBitmap* source,
 	BBitmap* target, float ratio, interpolation_type method)
 {
+	target->Lock();
 	uint32* target_bits = (uint32*)target->Bits();
 	int32 target_bpr = target->BytesPerRow() / 4;
+	target->Unlock();
+	source->Lock();
 	uint32* source_bits = (uint32*)source->Bits();
 	int32 source_bpr = source->BytesPerRow() / 4;
+	source->Unlock();
 
 	for (int32 y = 0; y <= (int32)height; y++) {
 		int32 low = floor(ratio * y);

--- a/artpaint/Utilities/ScaleUtilities.cpp
+++ b/artpaint/Utilities/ScaleUtilities.cpp
@@ -17,7 +17,7 @@ ScaleUtilities::ScaleHorizontally(float width, float height, BPoint offset, BBit
 	target->Lock();
 	uint32* target_bits = (uint32*)target->Bits();
 	int32 target_bpr = target->BytesPerRow() / 4;
-	target->Unlock();
+
 	source->Lock();
 	uint32* source_bits = (uint32*)source->Bits();
 	int32 source_bpr = source->BytesPerRow() / 4;
@@ -85,6 +85,8 @@ ScaleUtilities::ScaleHorizontally(float width, float height, BPoint offset, BBit
 			}
 		}
 	}
+
+	target->Unlock();
 }
 
 
@@ -95,7 +97,7 @@ ScaleUtilities::ScaleVertically(float width, float height, BPoint offset, BBitma
 	target->Lock();
 	uint32* target_bits = (uint32*)target->Bits();
 	int32 target_bpr = target->BytesPerRow() / 4;
-	target->Unlock();
+
 	source->Lock();
 	uint32* source_bits = (uint32*)source->Bits();
 	int32 source_bpr = source->BytesPerRow() / 4;
@@ -168,6 +170,8 @@ ScaleUtilities::ScaleVertically(float width, float height, BPoint offset, BBitma
 			}
 		}
 	}
+
+	target->Unlock();
 }
 
 


### PR DESCRIPTION
The code in line 22 of ScaleUtilities.cpp rounds up the height. for odd-heigth images this is needed when shrinking images otherwise there are artifacts on the bottom rows. for even-height images it can cause overflow when an image in enlarged. the fix is to only do the rounding up for odd height (but in the code it tests for even because the height is 1 less than the image size showing in the UI)

also added some locks around the code that gets the source and target bits for saftey from crashes, but that is not the reason for the crash in this case

Fixes #662