### PR TITLE
Fixes for slow scaling at high resolutions

### DIFF
--- a/artpaint/application/Selection.cpp
+++ b/artpaint/application/Selection.cpp
@@ -652,6 +652,8 @@ Selection::ScaleTo(BPoint origin, float x_scale, float y_scale)
 		p->ScaleBy(origin, dx, dy);
 	}
 
+	selection_bounds.right = selection_bounds.left + x_scale;
+	selection_bounds.bottom = selection_bounds.top + y_scale;
 	needs_recalculating = TRUE;
 	release_sem(selection_mutex);
 }


### PR DESCRIPTION
similar to https://github.com/HaikuArchives/ArtPaint/issues/661 I removed extra copies of the selection and also reduced the updated area so it is only the area updated when moving the selection or scaling it insted of the whole entire image.

there is a bug where if you move the selection up off the page to the left multiple times it sometimes doesn't draw the selection outline but it still works right. i had to really push the selection up in the corner off the page over and over to get it to show the bug so i dont think its a big problem becuase i think you have to purposely try to break it and also it seems to still work properly even if you do that. but overall i think this fix works pretty good.

Fixes #664 
