### PR TITLE
When transforming selected areas use src_over_fixed to comp the pixels instead of just setting them.

### DIFF
--- a/artpaint/viewmanipulators/ScaleManipulator.cpp
+++ b/artpaint/viewmanipulators/ScaleManipulator.cpp
@@ -722,7 +722,8 @@ ScaleManipulator::PreviewBitmap(bool, BRegion* region)
 							if (source_x < width && source_y < height &&
 								source_x >= 0 && source_y >= 0) {
 								*(target_bits + x + y_times_bpr)
-									= *(source_bits + source_x + source_y_times_bpr);
+									= src_over_fixed(*(target_bits + x + y_times_bpr),
+										*(source_bits + source_x + source_y_times_bpr));
 							}
 						}
 					}

--- a/artpaint/viewmanipulators/TranslationManipulator.cpp
+++ b/artpaint/viewmanipulators/TranslationManipulator.cpp
@@ -496,7 +496,8 @@ TranslationManipulator::PreviewBitmap(bool full_quality, BRegion* updated_region
 
 							if (selection->ContainsPoint(new_x , new_y) && new_x >= 0 && new_y >= 0)
 								*(target_bits + x + y * target_bpr)
-									= *(source_bits + new_x + new_y * source_bpr);
+									= src_over_fixed(*(target_bits + x + y * target_bpr),
+										*(source_bits + new_x + new_y * source_bpr));
 						}
 					}
 				}


### PR DESCRIPTION
seems like this worked a long time ago and then was changed by accident? 

Fixes #676