### PR TITLE
Address bad scaling behavior when scaling down to 1x1

### DIFF
--- a/artpaint/Utilities/ScaleUtilities.cpp
+++ b/artpaint/Utilities/ScaleUtilities.cpp
@@ -378,9 +378,16 @@ ScaleUtilities::MoveGrabbers(BPoint point, BPoint& previous, float& left, float&
 		}
 	}
 
-	if (left >= right)
+	if (left >= right && move_right == TRUE) {
+		left = right;
+		right = left + 1;
+	} else if (left >= right)
 		left = right - 1;
 
-	if (top >= bottom)
+
+	if (top >= bottom && move_bottom == TRUE) {
+		top = bottom;
+		bottom = top + 1;
+	} else if (top >= bottom)
 		top = bottom - 1;
 }

--- a/artpaint/viewmanipulators/ScaleManipulator.cpp
+++ b/artpaint/viewmanipulators/ScaleManipulator.cpp
@@ -683,21 +683,22 @@ ScaleManipulator::PreviewBitmap(bool, BRegion* region)
 			}
 		}
 
-		selection->Translate(settings->left - previous_left,
-			settings->top - previous_top);
+		sel_left = (int32)settings->left;
+		sel_top = (int32)settings->top;
 
-		selection->ScaleTo(BPoint(settings->left, settings->top), new_width, new_height);
+		selection->Translate(sel_left - (int32)previous_left,
+			sel_top - (int32)previous_top);
+
+		selection->ScaleTo(BPoint(sel_left, sel_top), new_width, new_height);
 		selection_bounds = selection->GetBoundingRect();
-		selection_bounds.OffsetBy(settings->left, settings->top);
+		selection_bounds.OffsetBy(sel_left, sel_top);
 
 		copy_of_the_preview_bitmap->Lock();
 		selection_bounds = selection_bounds & copy_of_the_preview_bitmap->Bounds();
 		copy_of_the_preview_bitmap->Unlock();
 
 		if (transform_selection_only == false) {
-			sel_top = (int32)settings->top;
 			sel_bottom = min_c((int32)settings->bottom, preview_bitmap->Bounds().bottom);
-			sel_left = (int32)settings->left;
 			sel_right = min_c((int32)settings->right, preview_bitmap->Bounds().right);
 
 			if (sel_right > 0 && sel_bottom > 0


### PR DESCRIPTION
Make sure values in ScaleManipulator::PreviewBitmap are int32. Otherwise float values make rounding errors and throw off the selection bounds. Also in ScaleUtilities::MoveGrabbers, fixed logic when scale size hits zero to reset top left point only if scaling from bottom/right. this fixes the selection box crepeing up to the left when it hits 1x1

Fixes #680