### PR TITLE
Refactor SelectorTool to not draw directly to ImageView

### DIFF
--- a/artpaint/paintwindow/Image.cpp
+++ b/artpaint/paintwindow/Image.cpp
@@ -1490,28 +1490,11 @@ Image::DoRenderPreview(BRect area, int32 resolution)
 		int32 right = (int32)area.right;
 		int32 bottom = (int32)area.bottom;
 
-		int32 gridSize;
-		uint32 color1;
-		uint32 color2;
+		union color_conversion white_bg;
+		white_bg.word = 0xFFFFFFFF;
+		white_bg.bytes[3] = 0x00;
 
-		gridSize = 20;
-		rgb_color rgb1, rgb2;
-		rgb1.red = rgb1.green = rgb1.blue = 0xBB;
-		rgb2.red = rgb2.green = rgb2.blue = 0x99;
-		rgb1.alpha = rgb2.alpha = 0xFF;
-		color1 = RGBColorToBGRA(rgb1);
-		color2 = RGBColorToBGRA(rgb2);
-
-		if (SettingsServer* server = SettingsServer::Instance()) {
-			BMessage settings;
-			server->GetApplicationSettings(&settings);
-
-			gridSize = settings.GetInt32(skBgGridSize, gridSize);
-			color1 = settings.GetUInt32(skBgColor1, color1);
-			color2 = settings.GetUInt32(skBgColor2, color2);
-		}
-
-		BitmapUtilities::CheckerBitmap(rendered_image, color1, color2, gridSize, &area);
+		BitmapUtilities::ClearBitmap(rendered_image, white_bg.word, &area);
 
 		for (int32 y = top; y <= bottom; y += resolution) {
 			for (int32 x = left; x <= right; x += resolution) {

--- a/artpaint/paintwindow/Image.h
+++ b/artpaint/paintwindow/Image.h
@@ -92,8 +92,8 @@ public:
 						Image(ImageView*, float, float, UndoQueue*);
 						~Image();
 
-			void		Render(bool bg = true);
-			void		Render(BRect, bool bg = true);
+			void		Render(bool bg = false);
+			void		Render(BRect, bool bg = false);
 			void		RenderPreview(BRect, int32);
 			void		RenderPreview(BRegion&, int32);
 			void		MultiplyRenderedImagePixels(int32);

--- a/artpaint/paintwindow/ImageView.h
+++ b/artpaint/paintwindow/ImageView.h
@@ -72,6 +72,7 @@ class ImageView : public BView {
 private:
 	friend filter_result KeyFilterFunction(BMessage*, BHandler**, BMessageFilter*);
 			Image*		the_image;
+			BBitmap*	background;
 
 			int32		mag_scale_array_length;
 			int32		mag_scale_array_index;
@@ -249,6 +250,7 @@ public:
 	const	char*		ReturnImageName() { return image_name; }
 
 			bool		ShowSelection() { return show_selection; }
+			void		MakeBackground();
 };
 
 filter_result KeyFilterFunction(BMessage*, BHandler**, BMessageFilter*);

--- a/artpaint/paintwindow/PaintWindow.cpp
+++ b/artpaint/paintwindow/PaintWindow.cpp
@@ -437,6 +437,7 @@ PaintWindow::Redraw()
 		ImageView* imgView = paintWin->ReturnImageView();
 		if (imgView != NULL) {
 			if (imgView->LockLooper() == true) {
+				imgView->MakeBackground();
 				imgView->ReturnImage()->Render();
 				imgView->Invalidate();
 				imgView->UnlockLooper();

--- a/artpaint/tools/ColorSelectorTool.cpp
+++ b/artpaint/tools/ColorSelectorTool.cpp
@@ -325,21 +325,6 @@ ColorSelectorTool::UseTool(ImageView* view, uint32 buttons, BPoint point, BPoint
 			rc.OffsetBySelf(-half_size, -half_size);
 			rc = rc & bounds;
 
-			view_rc = view->convertBitmapRectToView(rc);
-			scale = view->getMagScale();
-			view_rc.right -= scale;
-			view_rc.bottom -= scale;
-
-			if (view->LockLooper() == true) {
-				if (old_rc != view_rc) {
-					old_rc.InsetBySelf(-2, -2);
-					view->Draw(old_rc);
-					view->StrokeRect(view_rc, B_SOLID_HIGH);
-					view->StrokeRect(view_rc.InsetByCopy(-1, -1), B_SOLID_LOW);
-					old_rc = view_rc;
-				}
-				view->UnlockLooper();
-			}
 			int32 x_dist, y_sqr;
 
 			int32 width = rc.IntegerWidth();
@@ -397,11 +382,6 @@ ColorSelectorTool::UseTool(ImageView* view, uint32 buttons, BPoint point, BPoint
 			}
 			window->Unlock();
 			snooze(20 * 1000);
-		}
-
-		if (view->LockLooper() == true) {
-			view->Draw(view_rc.InsetByCopy(-1, -1));
-			view->UnlockLooper();
 		}
 
 		// Close the color picker window

--- a/artpaint/tools/EraserTool.cpp
+++ b/artpaint/tools/EraserTool.cpp
@@ -216,6 +216,7 @@ EraserTool::UseTool(ImageView* view, uint32 buttons, BPoint point, BPoint)
 			updated_rect.bottom
 				= max_c(point.y + brush_height_per_2 + 1, prev_point.y + brush_height_per_2 + 1);
 
+			updated_rect = updated_rect & buffer->Bounds();
 			imageUpdater->AddRect(updated_rect);
 
 			SetLastUpdatedRect(LastUpdatedRect() | updated_rect);

--- a/artpaint/tools/FreeLineTool.cpp
+++ b/artpaint/tools/FreeLineTool.cpp
@@ -189,6 +189,7 @@ FreeLineTool::UseTool(ImageView* view, uint32 buttons, BPoint point, BPoint)
 			updated_rect.bottom
 				= max_c(point.y + brush_height_per_2 + 1, prev_point.y + brush_height_per_2 + 1);
 
+			updated_rect = updated_rect & buffer->Bounds();
 			imageUpdater->AddRect(updated_rect);
 
 			SetLastUpdatedRect(LastUpdatedRect() | updated_rect);

--- a/artpaint/tools/HairyBrushTool.cpp
+++ b/artpaint/tools/HairyBrushTool.cpp
@@ -222,6 +222,8 @@ HairyBrushTool::UseTool(ImageView* view, uint32 buttons, BPoint point, BPoint)
 			updated_rect.right = ceil(updated_rect.right);
 			updated_rect.bottom = ceil(updated_rect.bottom);
 			updated_rect.InsetBy(-1, -1);
+			updated_rect = updated_rect & buffer->Bounds();
+
 			imageUpdater->AddRect(updated_rect);
 			SetLastUpdatedRect(updated_rect);
 		} else
@@ -340,6 +342,7 @@ HairyBrushTool::UseTool(ImageView* view, uint32 buttons, BPoint point, BPoint)
 			updated_rect.bottom = ceil(updated_rect.bottom);
 			updated_rect.InsetBy(-1, -1);
 
+			updated_rect = updated_rect & buffer->Bounds();
 			SetLastUpdatedRect(LastUpdatedRect() | updated_rect);
 
 			imageUpdater->AddRect(updated_rect);

--- a/artpaint/tools/SelectorTool.h
+++ b/artpaint/tools/SelectorTool.h
@@ -34,12 +34,14 @@ using ArtPaint::Interface::NumberSliderControl;
 class SelectorTool : public DrawingTool, public ToolEventAdapter {
 public:
 								SelectorTool();
+								~SelectorTool();
 
 			ToolScript*			UseTool(ImageView*, uint32, BPoint, BPoint);
 
 			BView*				ConfigView();
 			const void*			ToolCursor() const;
 			const char*			HelpString(bool isInUse) const;
+			void				DrawSelection(BView* view);
 
 private:
 								// These functions handle the magic wand thing.
@@ -52,6 +54,11 @@ private:
 									uint32, int32, BBitmap*);
 			BBitmap*			MakeFloodBinaryMap(BitmapDrawer*, int32, int32,
 									int32, int32, uint32, BPoint);
+
+			BPoint*				selectionPoints;
+			int32					numPoints;
+			BPoint*				activePoints;
+			int32				numActivePoints;
 };
 
 

--- a/artpaint/viewmanipulators/TranslationManipulator.cpp
+++ b/artpaint/viewmanipulators/TranslationManipulator.cpp
@@ -496,7 +496,8 @@ TranslationManipulator::PreviewBitmap(bool full_quality, BRegion* updated_region
 
 							if (selection->ContainsPoint(new_x , new_y) && new_x >= 0 && new_y >= 0)
 								*(target_bits + x + y * target_bpr)
-									= *(source_bits + new_x + new_y * source_bpr);
+									= src_over_fixed(*(target_bits + x + y * target_bpr),
+										*(source_bits + new_x + new_y * source_bpr));
 						}
 					}
 				}


### PR DESCRIPTION
- add SelectorTool to ImageView::DrawBrush so selection draws during Draw() function
- in SelectorTool store the points for a selection in progress. "selectionPoints" is for
drawing selections like rectangle or ellipse. "activePoints" is needed for intelligent scissors
because there is the part currenyly being drawn and then "selectionPoints" is for the part that the user
drew before clicking the mouse.
- add SelectorTool::DrawSelection function to draw in progress selections based on points stored
in SelectorTool::UseTool
- removed drawing code from SelectorTool::UseTool. store points for selections. use ImageUpdater
like other drawing tools to update the image instead of drawing directly to the view

NEEDS commit 1f79d690a66ba5f00434ba04ba0e6028f39f4de6

aka MUST TEST with https://github.com/HaikuArchives/ArtPaint/pull/685 applied first